### PR TITLE
reenable cache

### DIFF
--- a/gist.py
+++ b/gist.py
@@ -37,9 +37,14 @@ stats = Stats(engine)
 
 try :
     import pylibmc
-    mc = pylibmc.Client(["127.0.0.1"], binary=True,
-                    behaviors={"tcp_nodelay": True,
-                                "ketama": True})
+    mc = pylibmc.Client(
+        servers=[os.environ.get('MEMCACHE_SERVERS')],
+        username=os.environ.get('MEMCACHE_USERNAME'),
+        password=os.environ.get('MEMCACHE_PASSWORD'),
+        binary=True,
+         behaviors={"tcp_nodelay": True,
+                                "ketama": True}
+    )
 
     def cachedfirstparam(function):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ Pygments==1.5
 PyGithub==1.4
 Markdown==2.2.0
 psycopg2==2.4.5
+pylibmc==1.2.3


### PR DESCRIPTION
Add require pylibmc, and read env variable to setup memcache.

**Not sure** if there is a **big** improvement with cache (5mb free plan), I went up to ~3.5/4 req/sec vs 2.6/3 with `ab -n 10 -c 10` hitting a single notebook. 

We should apache bench on several url in parallel and try other addons with more cache.
