### PR TITLE
fix links for IPython example notebooks

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -102,7 +102,7 @@
     </li>
     <li class="span6">
       <p class="marketing-byline"> Cython extension</p>
-      <a class="thumbnail" href="urls/raw.github.com/ipython/ipython/3607712653c66d63e0d7f13f073bde8c0f209ba8/docs/examples/notebooks/cython_extension.ipynb" target="_blank">
+      <a class="thumbnail" href="urls/raw.github.com/ipython/ipython/master/examples/notebooks/Cython Magics.ipynb" target="_blank">
         <img src="/static/img/example-nb/cython.png" >
       </a>
     </li>
@@ -119,8 +119,8 @@
       </a>
     </li>
     <li class="span6">
-      <p class="marketing-byline"> Sympy notebook</p>
-      <a class="thumbnail" href="urls/raw.github.com/ipython/ipython/master/docs/examples/notebooks/sympy.ipynb" target="_blank">
+      <p class="marketing-byline"> SymPy notebook</p>
+      <a class="thumbnail" href="urls/raw.github.com/ipython/ipython/master/examples/notebooks/SymPy Examples.ipynb" target="_blank">
         <img src="/static/img/example-nb/sympy.png" >
       </a>
     </li>
@@ -138,7 +138,7 @@
     </li> 
     <li class="span6">
       <p class="marketing-byline"> R magic extension</p>
-      <a class="thumbnail" href="urls/raw.github.com/ipython/ipython/3607712653c66d63e0d7f13f073bde8c0f209ba8/docs/examples/notebooks/rmagic_extension.ipynb" target="_blank">
+      <a class="thumbnail" href="urls/raw.github.com/ipython/ipython/master/examples/notebooks/R Magics.ipynb" target="_blank">
         <img src="/static/img/example-nb/r_magic.png" >
       </a>
     </li>


### PR DESCRIPTION
They moved.

closes #22
