### PR TITLE
Add a tweet-it link

### DIFF
--- a/gist.py
+++ b/gist.py
@@ -259,12 +259,16 @@ def render_content(content, url=None, forced_theme=None):
     
     if not name.endswith(".ipynb"):
         name = name + ".ipynb"
+
+    title = name[:-6].replace('_',' ')
+
     
     config = {
             'download_url': url,
             'download_name': name,
             'css_theme': css_theme,
             'mathjax_conf': None,
+            'title':title
             }
     return body_render(config, body=C.convert(nb)[0])#body_render(config, body)
 

--- a/templates/notebook.html
+++ b/templates/notebook.html
@@ -5,10 +5,13 @@
         <li class="{{index}}">
             <a href="{{download_url}}" download="{{download_name}}">Download Notebook</a>
         </li>
+        <li class="{{index}}">
+            <a href='javascript:window.open("https://twitter.com/share?related=IPython-dev&via=nbviewer&hashtags=IPython,nbviewer&text={{title}}&url="+window.location.href,"_blank")'>Tweet it</a>
     </ul>
     {% endblock %}
 
     {% block extra_head %}
+    <title>{{title}}</title>
     <style type="text/css" media='screen and (min-width:980px)'>
     .navbar-inner {
         opacity: 0.5;


### PR DESCRIPTION
<notebook title> via @nbviewer [link] #IPython #nbviewer

(or something like that)

Should propose to follow @nbviewer and @IPython-dev once tweet posted.

Thought if we should put it in a submenu ? At the bottom of the page? 

[the subproject change is a mistake, I'll revert it and force push]
