### PR TITLE
Added sqlalchemy to requirements file (used by gist.py)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ newrelic
 -e git://github.com/thadeusb/flask-cache.git@40cfd9280dc66ea54df0961420fc94853d506a35#egg=Flask-Cache
 
 ipython
+sqlalchemy
 


### PR DESCRIPTION
Made a fresh virtualenv, and tried to get a server running locally:

  $ pip install -r requirements.txt
  ...
  $ python app.py 
  Traceback (most recent call last):
    File "app.py", line 5, in <module>
      from gist import app as gist
    File "/home/kyle/nbviewer/gist.py", line 13, in <module>
      from sqlalchemy import create_engine
  ImportError: No module named sqlalchemy

Simply added sqlalchemy to requirements.txt (but didn't pin a version). Life is good now.
