### PR TITLE
bump requests to stable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==0.9
 Flask-Markdown
-requests==0.13.5
+requests
 Pygments
 Markdown==2.2.0
 pylibmc==1.2.3


### PR DESCRIPTION
This should fix some traceback with socket.gaierror
That are annoying in logs.

Haven't tried on my heroku fork, but have to run now.
