### PR TITLE
disable strict trailing-slash

### DIFF
--- a/gist.py
+++ b/gist.py
@@ -34,6 +34,7 @@ class RegexConverter(BaseConverter):
 app = Flask(__name__)
 Markdown(app)
 app.url_map.converters['regex'] = RegexConverter
+app.url_map.strict_slashes = False
 
 app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', 'sqlite://')
 app.config['GITHUB'] = {


### PR DESCRIPTION
allows `nbviewer.ipython.org/gist-id/` without 404 error.

As requested by @fperez, specifically for listing multi-file gists with the logical url, such as this:

http://nbtest.herokuapp.com/3693491/

Technically, this also allows _any_ gist to be viewed with trailing slash. Due to apparent limitations of werkzeug, it doesn't seem possible to simply redirect 'gist-id/' to 'gist-id', since both will be routed to the same handler.
