### PR TITLE
support `files` in 1.0

### DIFF
--- a/gist.py
+++ b/gist.py
@@ -67,7 +67,9 @@ from IPython.config import Config
 config = Config()
 config.HTMLExporter.template_file = 'basic'
 config.NbconvertApp.fileext = 'html'
-config.CSSHtmlHeaderTransformer.enabled = False
+config.CSSHTMLHeaderTransformer.enabled = False
+# don't strip the files prefix - we use it for redirects
+config.Exporter.filters = {'strip_files_prefix': lambda s: s}
 
 C = HTMLExporter(config=config)
 


### PR DESCRIPTION
This simply disables the `strip_files_prefix` filter, since we are detecting it and using it for redirects.

We will need to think more carefully when the `files/` prefix is no longer in files to begin with.
