### PR TITLE
Cookies! Only set theme if not None, coerce nvisits to str

### DIFF
--- a/gist.py
+++ b/gist.py
@@ -98,12 +98,9 @@ def favicon():
 def hello():
     nvisit = int(request.cookies.get('rendered_urls', 0))
     betauser = (True if nvisit > 30 else False)
-    theme = request.cookies.get('theme', None)
 
     response = _hello(betauser)
 
-    if(theme):
-        response.set_cookie('theme', value=theme)
     return response
 
 @cache.cached(5*hours)
@@ -171,8 +168,6 @@ def create(v=None):
         response = redirect('/url/'+value)
 
     response = app.make_response(response)
-    nvisit = int(request.cookies.get('rendered_urls', 0))
-    response.set_cookie('rendered_urls', value=str(nvisit+1))
     return response
 
 #https !


### PR DESCRIPTION
Upon deploying nbviewer following the instructions, it ran into several issues with the cookie setting.

When theme is `None`, it causes an issue with werkzeug, as it expects an iterable:

``` python-traceback
[2013-10-17 17:28:25,137] ERROR: Exception on / [GET]
Traceback (most recent call last):
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/flask/app.py", line 1687, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/flask/app.py", line 1360, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/flask/app.py", line 1358, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/flask/app.py", line 1344, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/share/nbviewer/gist.py", line 105, in hello
    response.set_cookie('theme', value=theme)
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/werkzeug/wrappers.py", line 992, in set_cookie
    self.charset))
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/werkzeug/http.py", line 918, in dump_cookie
    buf = [key + b'=' + _cookie_quote(value)]
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/werkzeug/_internal.py", line 223, in _cookie_quote
    for char in iter_bytes(b):
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/werkzeug/_compat.py", line 28, in <lambda>
    iter_bytes = lambda x: iter(x)
TypeError: 'NoneType' object is not iterable
```

When `rendered_urls` gets set, it's expecting a string.

``` python-traceback
[2013-10-17 17:28:51,224] ERROR: Exception on /create/ [POST]
Traceback (most recent call last):
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/flask/app.py", line 1687, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/flask/app.py", line 1360, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/flask/app.py", line 1358, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/flask/app.py", line 1344, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/share/nbviewer/gist.py", line 174, in create
    response.set_cookie('rendered_urls', value=nvisit+1)
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/werkzeug/wrappers.py", line 992, in set_cookie
    self.charset))
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/werkzeug/http.py", line 905, in dump_cookie
    value = to_bytes(value, charset)
  File "/usr/share/nbviewer/venv/local/lib/python2.7/site-packages/werkzeug/_compat.py", line 106, in to_bytes
    raise TypeError('Expected bytes')
TypeError: Expected bytes
```

The [full tracebacks from a supervisor log](https://gist.github.com/rgbkrk/7029209) are on gist.github.com.
