### PR TITLE
overwrite bootstrap pre-background color

### DIFF
--- a/templates/notebook.html
+++ b/templates/notebook.html
@@ -51,6 +51,10 @@
         opacity: 1.0;
     }
 
+    .highlight pre {
+        background-color: transparent;
+    }
+
     </style>
     {% if css_theme %}
         <link href="/static/css/theme/{{css_theme}}.css" rel="stylesheet">


### PR DESCRIPTION
On nbviewer the cell are of 2 slightly different color and it's starting to bug me a lot. 
It is not the case with pure nbconvert, because it does not include bootstrap css.
