### PR TITLE
redirect blob to tree

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -429,6 +429,7 @@ class GitHubBlobHandler(RenderingHandler):
     
     - notebook, render it
     - non-notebook file, serve file unmodified
+    - directory, redirect to tree
     """
     @cached
     @gen.coroutine
@@ -444,6 +445,16 @@ class GitHubBlobHandler(RenderingHandler):
             response = yield self.client.fetch(raw_url)
         except httpclient.HTTPError as e:
             raise web.HTTPError(e.code)
+        
+        if response.effective_url.startswith("https://github.com/{user}/{repo}/tree".format(
+            user=user, repo=repo
+        )):
+            tree_url = "/github/{user}/{repo}/tree/{ref}/{path}/".format(
+                user=user, repo=repo, ref=ref, path=quote(path),
+            )
+            app_log.info("%s is a directory, redirecting to %s", raw_url, tree_url)
+            self.redirect(tree_url)
+            return
         
         filedata = response.body
         

--- a/nbviewer/tests/test_github.py
+++ b/nbviewer/tests/test_github.py
@@ -72,3 +72,12 @@ class GitHubTestCase(NBViewerTestCase):
         # verify redirect
         self.assertIn('/github/ipython/ipython/blob/master', r.request.url)
         self.assertIn('global-exclude', r.text)
+
+    def test_github_blob_redirect(self):
+        url = self.url("github/ipython/ipython/blob/master/IPython")
+        r = requests.get(url)
+        self.assertEqual(r.status_code, 200)
+        # verify redirect
+        self.assertIn('/github/ipython/ipython/tree/master/IPython', r.request.url)
+        self.assertIn('__init__.py', r.text)
+


### PR DESCRIPTION
relies on raw.github.com redirect behavior, which may not be reliable (I think it's different now from a few days ago).

closes #125
