### PR TITLE
turn any exception rendering a notebook into 400

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -332,6 +332,9 @@ class RenderingHandler(BaseHandler):
                     render_notebook, self.exporter, nbjson, download_url,
                 )
         except NbFormatError as e:
+            app_log.error("Invalid notebook %s: %s", msg, e)
+            raise web.HTTPError(400, str(e))
+        except Exception as e:
             app_log.error("Failed to render %s", msg, exc_info=True)
             raise web.HTTPError(400, str(e))
         else:


### PR DESCRIPTION
not just NbFormatError

and only show tracebacks on the non-nbformat errors.
