### PR TITLE
Link issues page

### DIFF
--- a/nbviewer/templates/500.html
+++ b/nbviewer/templates/500.html
@@ -2,7 +2,7 @@
 {% block error_detail %}
 <p>You broke the internet!</p>
 <p class="marketing-byline">Kidding, this might just be an intermittent failure in nbviewer.</p>
-<p class="marketing-byline"> If this is reproducible, please <a href="https://github.com/ipython/nbviewer/issues?state=open">send us a bug report</a>!</p>
+<p class="marketing-byline"> If this is reproducible, please <a href="https://github.com/ipython/nbviewer/issues">send us a bug report</a>!</p>
 {% if message %}
 <p class="marketing-byline">The upstream error was {{message}}</p>
 {% endif %}


### PR DESCRIPTION
Motivated by #105, added a link to add a new issue when a notebook render fails. This is only for 5xx error codes.
