### PR TITLE
Change open-in-nbviewer link

### DIFF
--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -56,7 +56,7 @@
                 <a href="http://www.ipython.org">IPython</a>
               </li>
               <li>
-              <a href="http://penandpants.com/2012/10/16/open-in-nbviewer-bookmarklet/">Bookmarklet</a>
+              <a href="http://jiffyclub.github.io/open-in-nbviewer/">Open-in-nbviewer</a>
               </li>
               {% if betauser %}
                   <li class="{{index}}">


### PR DESCRIPTION
nbviewer has been linking to my blog post about the open-in-nbviewer bookmarklet, but I also maintain browser extensions that people may be interested in. This updates the navbar to link to the Open-in-nbviewer project page, which includes the bookmarklet and browser extensions.
