### PR TITLE
added missing jinja2 and pygments packages to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,7 @@ pylibmc
 futures
 newrelic
 markdown
+jinja2
+pygments
 
 ipython[nbconvert]>=1.1.0


### PR DESCRIPTION
These packages were missing after running `pip install -r requirements`
