### PR TITLE
Fixed handling notebooks from shared folders

### DIFF
--- a/nbviewer/tests/test_utils.py
+++ b/nbviewer/tests/test_utils.py
@@ -27,10 +27,12 @@ def test_transform_ipynb_uri():
         ('http://github.com/user/repo/blob/master/path/file.ipynb',
         u'/github/user/repo/blob/master/path/file.ipynb'),
         #DropBox Urls
-        ( u'http://www.dropbox.com/u/bar/baz.qux',
-          u'/url/dl.dropbox.com/u/bar/baz.qux'),
-        ( u'https://www.dropbox.com/u/zip/baz.qux',
-          u'/urls/dl.dropbox.com/u/zip/baz.qux'),
+        ( u'http://www.dropbox.com/s/bar/baz.qux',
+          u'/url/dl.dropbox.com/s/bar/baz.qux'),
+        ( u'https://www.dropbox.com/s/zip/baz.qux',
+          u'/urls/dl.dropbox.com/s/zip/baz.qux'),
+        ( u'https://www.dropbox.com/sh/mhviow274da2wly/CZKwRRcA0k/nested/furthernested/User%2520Interface.ipynb',
+          u'/urls/dl.dropbox.com/sh/mhviow274da2wly/CZKwRRcA0k/nested/furthernested/User%2520Interface.ipynb'),
         # URL
         ('https://example.org/ipynb',
         u'/urls/example.org/ipynb'),

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -49,7 +49,7 @@ GIST_RGX = re.compile(r'^([a-f0-9]+)/?$')
 GIST_URL_RGX = re.compile(r'^https?://gist.github.com/(\w+/)?([a-f0-9]+)/?$')
 GITHUB_URL_RGX = re.compile(r'^https?://github.com/(\w+)/(\w+)/blob/(.*)$')
 RAW_GITHUB_URL_RGX = re.compile(r'^https?://raw.?github.com/(\w+)/(\w+)/(.*)$')
-DROPBOX_URL_RGX = re.compile(r'^http(s?)://www.dropbox.com/(\w)/(\w+)/(.+)$')
+DROPBOX_URL_RGX = re.compile(r'^http(s?)://www.dropbox.com/(sh?)/(.+)$')
 
 
 #def url_rewrite(value):
@@ -66,7 +66,7 @@ url_rewrite_dict = OrderedDict({
         GIST_URL_RGX       : u'/{1}',
         GITHUB_URL_RGX     : u'/github/{0}/{1}/blob/{2}',
         RAW_GITHUB_URL_RGX : u'/github/{0}/{1}/blob/{2}',
-        DROPBOX_URL_RGX    : u'/url{0}/dl.dropbox.com/{1}/{2}/{3}',
+        DROPBOX_URL_RGX    : u'/url{0}/dl.dropbox.com/{1}/{2}',
     })
 
 


### PR DESCRIPTION
Shared folders have a different structure than shared files. Example:

https://www.dropbox.com/sh/mhviow274da2wly/CZKwRRcA0k/nested/furthernested/User%2520Interface.ipynb

This PR simply changes `www` to `dl` when the path starts with `s` or `sh` and adds a test for this type of URL.
