### PR TITLE
add missing parentheses in log_request

### DIFF
--- a/nbviewer/log.py
+++ b/nbviewer/log.py
@@ -19,7 +19,7 @@ def log_request(handler):
     """
     status = handler.get_status()
     request = handler.request
-    if status < 300 or status == 304 and isinstance(handler, StaticFileHandler):
+    if (status < 300 or status == 304) and isinstance(handler, StaticFileHandler):
         # static-file get successes (or 304 FOUND) are debug-level
         log_method = access_log.debug
     elif status < 400:


### PR DESCRIPTION
it's meant to be "static file (success or 304)", not "success or (static file 304)".
