### PR TITLE
Redirect Tree view to Index.ipynb if it exists

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -476,6 +476,7 @@ class GistHandler(RenderingHandler):
                 # If we find an index while iterating, bail and display the
                 # index file instead
                 if filename.lower() == 'index.ipynb':
+                    user = user.strip('/')
                     index_url = ('/gist/{user}/{gist_id}/{filename}'
                                     .format(user=user, gist_id=gist_id,
                                             filename=filename))


### PR DESCRIPTION
First pass on #181, adding an index page.

I've deployed this to qa and have two samples:
## GitHub repository

http://qa2.nb.minrk.net/github/rgbkrk/index.ipynb/tree/master/
## Gist with index.ipynb

http://qa2.nb.minrk.net/gist/rgbkrk/8653938

---

While testing this out, it seems like we don't have redirection to a tree enabled (have to know the magic behind nbviewer's URLs to list a repo). Am I missing something here?
