### PR TITLE
Use the master branch of IPython, targeting 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,4 @@ futures
 newrelic
 markdown
 
-Jinja2==2.7.2
-MarkupSafe==0.18
-Pygments==1.6
-Sphinx==1.2.1
-docutils==0.11
-wsgiref==0.1.2
-
--e git+https://github.com/ipython/ipython.git#egg=ipython-dev
+-e git+https://github.com/ipython/ipython.git#egg=ipython[nbconvert]


### PR DESCRIPTION
This purposefully pulls from the git master of ipython/ipython, so we can try IPython 2.0 out on nbviewer (see #188).

Deploying this shortly, will update the PR.

When we think this is stable and IPython 2.0 comes out, we can switch wholeheartedly.
