### PR TITLE
Use IPython 1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ futures
 newrelic
 markdown
 
--e git+https://github.com/ipython/ipython.git#egg=ipython[nbconvert]
+ipython[nbconvert]==1.2.0


### PR DESCRIPTION
For the sake of sanity while we run the "Let's try IPython 2.0 on the masses" test, since Travis doesn't seem to enjoy installing from git, let's lock nbviewer down to `IPython==1.2.0`.

nbviewer.ipython.org will still run off the master branch of IPython for the time being.
