### PR TITLE
Use the download attribute for the download notebook button

### DIFF
--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -1,6 +1,6 @@
-{% macro head_link(url, name, icon=None) -%}
+{% macro head_link(url, name, icon=None, download=False) -%}
    <li>
-        <a href="{{url}}" title="{{name}}">
+        <a href="{{url}}" title="{{name}}" {%if download %}download{% endif %}>
            {% if icon %}
                <span class='fa fa-{{icon}} fa-2x menu-icon'></span>
                <span class='menu-text'>{{name}}</span>

--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -6,7 +6,7 @@
       {% if home_url %}
         {{ layout.head_link(home_url    , "Notebook Home"    , "github"  ) }}
       {% endif %}
-        {{ layout.head_link(download_url, "Download Notebook", "download") }}
+        {{ layout.head_link(download_url, "Download Notebook", "download", True) }}
     {% endblock %}
 
     {% block extra_head %}


### PR DESCRIPTION
This makes the browser more likely to download the notebook instead of viewing its content, e.g. from raw.github.com

Unfortunately, this only works in Chrome, because Firefox doesn't let you force a cross-domain link to download (to be fair, that's what the spec says).
