### PR TITLE
add missing min-width change from #204

### DIFF
--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -62,7 +62,7 @@
             top:5px;
         }
         
-        @media (min-width: 980px){
+        @media (min-width: 768px){
             .menu-text{
                 display:none
             }


### PR DESCRIPTION
caused 'Download Notebook' text to be visible in the 768-979 range
