### PR TITLE
Removing manual style overrides that will soon be done in ipython.

### DIFF
--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -57,18 +57,6 @@
     .imgwrap {
         text-align: center;
     }
-    .input_area{
-        padding: 0.4em;
-    }
-    div.input_area > div.highlight > pre {
-        margin: 0px;
-        padding: 0px;
-        border: none;
-    }
-
-    .highlight pre {
-        background-color: transparent;
-    }
 
     @media (max-width: 767px){
 


### PR DESCRIPTION
Previously, we were styling the `input_area&div.highlight&pre` manually in the `notebook.html` template. In this PR:

https://github.com/ipython/ipython/pull/5232

We are exploring handling this style in the actual `ipython.min.css`. This PR should be merged until we decide what to do with #5232.
