### PR TITLE
Install IPython from the beta release tarball

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,7 @@ futures
 newrelic
 markdown
 
+pygments
+jinja2
+Sphinx>=0.3
 http://archive.ipython.org/testing/2.0.0/ipython-2.0.0-b1.tar.gz


### PR DESCRIPTION
This sets the requirements.txt to use the beta release tarball, and directly adds nbconvert requirements.

I couldn't seem to get the requirements.txt file installation method to handle installing from wheels. Perhaps it's time we make ourselves less beholden to all pip ways.

Once we get this in, we can start merging @ellisonbg's UI changes more easily.
