### PR TITLE
add ipython>=1.2.1 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ markdown
 pygments
 jinja2
 Sphinx>=0.3
-http://archive.ipython.org/testing/2.0.0/ipython-2.0.0-b1.tar.gz
+
+ipython>=1.2.1


### PR DESCRIPTION
this way, already installed IPython dev will still satisfy the requirement, rather than being rolled back.
