### PR TITLE
Simplify the subtitles on the main page

### DIFF
--- a/nbviewer/templates/index.html
+++ b/nbviewer/templates/index.html
@@ -17,8 +17,7 @@
 <header class="jumbotron masthead">
   <div class="inner">
     <h1>IPython Notebook Viewer</h1>
-    <p>A simple way to share your IPython Notebooks</p>
-    <p class="marketing-byline">Share your own notebook, and browse others'</p>
+    <p>A simple way to share IPython Notebooks</p>
     <form class='well' method="post" action='create/'>
             <div class="" style='text-align:center'>
               <div class="">


### PR DESCRIPTION
Previously we had two subtitles that basically said the same thing. This removes one of them and cleans up the other.

![screen shot 2014-03-30 at 3 13 24 pm](https://cloud.githubusercontent.com/assets/27600/2562659/917b2ec4-b858-11e3-8b8c-760c6d1e7256.png)

![screen shot 2014-03-30 at 3 13 36 pm](https://cloud.githubusercontent.com/assets/27600/2562660/93a339ee-b858-11e3-84eb-f98669b82d9c.png)
