### PR TITLE
Change description heading and link for IPython on nbviewer home page.

### DIFF
--- a/nbviewer/frontpage.json
+++ b/nbviewer/frontpage.json
@@ -4,7 +4,7 @@
     "links":[
       {
         "text": "IPython",
-        "target": "github/ipython/ipython/tree/master/examples/notebooks",
+        "target": "github/ipython/ipython/tree/master/examples/Index.ipynb",
         "img": "/static/img/example-nb/ipython-thumb.png"
       },
       {


### PR DESCRIPTION
With 2.0, the "examples" directory is no longer just examples. It now contains more general documentation content with Index.ipynb files that organize that content into a unified narrative. OK, maybe we are not quite there yet, but that is where things are headed.

This PR is designed to change the frontpage of nbviewer to reflect this change:
- [x] Change "IPython Examples" to just "IPython".
- [ ] Change the link URL to point to the top-level Index.ipynb file. This can't happen until https://github.com/ipython/ipython/pull/5337 is merged.
