### PR TITLE
Use "Notebook Viewer" instead of house icon in header.

### DIFF
--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -1,15 +1,22 @@
-{% macro head_link(url, name, icon=None, download=False) -%}
-   <li>
+{% macro head_text(url, name, bold=False) -%}
+    <li>
         <a href="{{url}}" title="{{name}}" {%if download %}download{% endif %}>
-           {% if icon %}
-               <span class='fa fa-{{icon}} fa-2x menu-icon'></span>
-               <span class='menu-text'>{{name}}</span>
-           {% else %}
-               <span>{{name}}</span>
-           {% endif %}
-       </a>
-   </li>
+            {% if bold %}<strong>{% endif %}
+            <span>{{name}}</span>
+            {% if bold %}</strong>{% endif %}
+        </a>
+    </li>
 {%- endmacro %}
+
+{% macro head_icon(url, name, icon, download=False) -%}
+    <li>
+        <a href="{{url}}" title="{{name}}" {%if download %}download{% endif %}>
+            <span class='fa fa-{{icon}} fa-2x menu-icon'></span>
+            <span class='menu-text'>{{name}}</span>
+        </a>
+    </li>
+{%- endmacro %}
+
 
 {% macro link_breadcrumbs(crumbs) -%}
 {% if crumbs %}
@@ -91,8 +98,8 @@
           <div class="nav-collapse collapse">
             <ul class="nav">
 
-                {{ head_link('/'    , "Home"    , "home"    ) }}
-                {{ head_link('/faq'    , "FAQ" ) }}
+                {{ head_text('/', "Notebook Viewer", True) }}
+                {{ head_text('/faq', "FAQ") }}
 
               <li class="{{index}}">
                 <a href="http://www.ipython.org">IPython</a>

--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -4,9 +4,9 @@
 
     {% block otherlinks %}
       {% if home_url %}
-        {{ layout.head_link(home_url    , "Notebook Home"    , "github"  ) }}
+        {{ layout.head_icon(home_url, "Notebook Home", "github") }}
       {% endif %}
-        {{ layout.head_link(download_url, "Download Notebook", "download", True) }}
+        {{ layout.head_icon(download_url, "Download Notebook", "download", True) }}
     {% endblock %}
 
     {% block extra_head %}


### PR DESCRIPTION
Right now, we use an house icon in the header to take the user back to the home nbviewer page. The problem is that on all but the home page, there is nothing to indicate what website the user it on. This enhances the confusion that users have between the live notebook and nbviewer. This PR removes the house icon and uses the bold text "Notebook Viewer" in the header instead.

![screen shot 2014-04-01 at 10 47 49 am](https://cloud.githubusercontent.com/assets/27600/2582524/0403e166-b9c6-11e3-8f88-a1145536c790.png)
