### PR TITLE
Reduce huge jumbotron bottom margin to something more consistent.

### DIFF
--- a/nbviewer/static/css/nbviewer.css
+++ b/nbviewer/static/css/nbviewer.css
@@ -10,6 +10,10 @@
     }
 }
 
+.jumbotron {
+  margin-bottom: 30px;
+}
+
 .menu-icon{
     line-height: 8px;
     margin-right: 5px;


### PR DESCRIPTION
We were wasting a ton of vertical space. Here is the new look:

![screen shot 2014-04-01 at 10 56 57 am](https://cloud.githubusercontent.com/assets/27600/2582605/1bbe2090-b9c7-11e3-916d-e352e502106f.png)
