### PR TITLE
Updating IPython notebook text and link.

### DIFF
--- a/nbviewer/frontpage.json
+++ b/nbviewer/frontpage.json
@@ -89,7 +89,7 @@
       },
       {
         "text": "SymPy notebook",
-        "target": "github/ipython/ipython/blob/master/examples/notebooks/SymPy Examples.ipynb",
+        "target": "github/ipython/ipython/blob/2.x/examples/Notebook/SymPy.ipynb",
         "img": "/static/img/example-nb/sympy.png"
       },
       {


### PR DESCRIPTION
Right now the main nbviewer page has a link for "IPython Examples" that points to master. This PR makes 2 changes:
- We agreed that our docs should always point to our 2.x branch, not master.
- The title text is changed to "IPython 2.0" to reflect that these notebooks are not just examples.
