### PR TITLE
tweak handling of slow/missing upstream

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -157,6 +157,9 @@ def main():
         gzip=True,
         render_timeout=20,
         localfile_path=os.path.abspath(options.localfiles),
+        fetch_kwargs=dict(
+            connect_timeout=10,
+        ),
     )
     
     # create and start the app

--- a/nbviewer/client.py
+++ b/nbviewer/client.py
@@ -25,9 +25,10 @@ class LoggingAsyncHTTPClient(object):
             request.user_agent = 'Tornado-Async-Client'
 
         def log_callback(result):
-            dt = time.time() - tic
-            log = app_log.info if dt > 1 else app_log.debug
-            log("Fetched  %s in %.2f ms", without_params, 1e3 * dt)
+            if not result.error:
+                dt = time.time() - tic
+                log = app_log.info if dt > 1 else app_log.debug
+                log("Fetched  %s in %.2f ms", without_params, 1e3 * dt)
             callback(result)
         return super(LoggingAsyncHTTPClient, self).fetch_impl(request, log_callback)
     


### PR DESCRIPTION
our fetch and render timeouts were both 20s, causing the 'finish early' event to fire immediately before the upstream timeout turns it into a 400.

This moves the upstream connection timeout to 10s, meaning unavailable servers will hit 400 instead of 'working...'.

I also removed the 'Fetched...' timing diagnostic message when the fetch fails.

and switched the HTTP status for the working... message to 202: Accepted from 200.
