### PR TITLE
GitHub client shouldn't authenticate twice

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -140,7 +140,6 @@ def main():
     AsyncHTTPClient.configure(HTTPClientClass)
     client = AsyncHTTPClient()
     github_client = AsyncGitHubClient(client)
-    github_client.authenticate()
     
     settings = dict(
         log_function=log_request,


### PR DESCRIPTION
The `authenticate()` method is called in the AsyncGitHubClient constructor (see [line 25 of github.py](https://github.com/ipython/nbviewer/blob/master/nbviewer/github.py#L25)), so we don't need to call `authenticate()` again here.
