### PR TITLE
Fixing footer formatting that got broken in recent work

### DIFF
--- a/nbviewer/static/css/nbviewer.css
+++ b/nbviewer/static/css/nbviewer.css
@@ -30,3 +30,14 @@ pre, code {
     /* restore default mono font */
     font-family: monospace;
 }
+
+.footer {
+  padding-top: 0px;
+  padding-bottom: 0px;
+  margin-top: 15px;
+}
+
+.footer-row {
+  margin-top: 25px;
+  margin-bottom: 25px;
+}

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -123,22 +123,26 @@
 
      {% block body %}{% endblock %}
 
+     <!-- <hr/> -->
+     <div class="row">
       <div class="span12 text-center">
         <a href="#">Back to top</a>
       </div>
+    </div>
 
      <!-- Footer
      ================================================== -->
       {% block footer %}
       <footer class="footer">
-      <div class="span12 row-fluid footer">
-          <div class="span8">
-            <p>
-            This web site does not host notebooks, it only renders notebooks available on other websites.
-            Thanks to <a href="http://www.rackspace.com">Rackspace</a> for hosting.
-            <a href="https://github.com/ipython/nbviewer">More Info</a>,
-            <a href="https://github.com/ipython/nbviewer/blob/master/LICENSE.txt" target="_blank">License</a>.
-            </p>
+      <div class="span12 row-fluid footer-row">
+          <div class="span4">
+            <p>This web site does not host notebooks, it only renders notebooks available on other websites.</p>
+          </div>
+
+          <div class="span4">
+            <p>Thanks to <a href="http://www.rackspace.com">Rackspace</a> for hosting.</p>
+            <p>nbviewer GitHub <a href="https://github.com/ipython/nbviewer">repository</a>.</p>
+            <p>nbviewer <a href="https://github.com/ipython/nbviewer/blob/master/LICENSE.txt" target="_blank">license</a>.</p>
           </div>
 
           <div class="span4">


### PR DESCRIPTION
Somehow the CSS and formatting of the footer got messed up in recent work, with multiple borders that are offset and vertical spacing that is too abundant. This cleans that up and goes a bit further with cleaning up the multiple columns and the descriptive text.

Here is currently deployed nbviewer footer:

![screen shot 2014-04-22 at 8 46 07 pm](https://cloud.githubusercontent.com/assets/27600/2773418/e132f4ee-ca99-11e3-94d5-39a46636a491.png)

And with this PR:

![screen shot 2014-04-22 at 8 45 02 pm](https://cloud.githubusercontent.com/assets/27600/2773419/e5d5830e-ca99-11e3-83b8-5a58bfab67e6.png)

![screen shot 2014-04-22 at 8 45 17 pm](https://cloud.githubusercontent.com/assets/27600/2773420/e8851c18-ca99-11e3-9cf7-ce590453ef00.png)
