### PR TITLE
use GitHub blobs API

### DIFF
--- a/nbviewer/github.py
+++ b/nbviewer/github.py
@@ -5,13 +5,15 @@
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 
+import json
 import os
 
-from tornado.httpclient import AsyncHTTPClient
+from tornado.concurrent import Future
+from tornado.httpclient import AsyncHTTPClient, HTTPError
 from tornado.httputil import url_concat
 from tornado.log import app_log
 
-from .utils import url_path_join, quote
+from .utils import url_path_join, quote, response_text
 
 #-----------------------------------------------------------------------------
 # Async GitHub Client
@@ -68,10 +70,57 @@ class AsyncGitHubClient(object):
     def get_repos(self, user, callback=None, **kwargs):
         """List a user's repos"""
         path = u"users/{user}/repos".format(user=user)
-        return self.github_api_request(path, callback ,**kwargs)
+        return self.github_api_request(path, callback, **kwargs)
     
     def get_gists(self, user, callback=None, **kwargs):
         """List a user's gists"""
         path = u"users/{user}/gists".format(user=user)
-        return self.github_api_request(path, callback ,**kwargs)
+        return self.github_api_request(path, callback, **kwargs)
+    
+    def get_tree(self, user, repo, ref='master', recursive=False, callback=None, **kwargs):
+        """Get a git tree"""
+        path = u"repos/{user}/{repo}/git/trees/{ref}".format(**locals())
+        if recursive:
+            params = kwargs.setdefault('params', {})
+            params['recursive'] = True
+        return self.github_api_request(path, callback, **kwargs)
+    
+    def _extract_tree_entry(self, path, tree_response):
+        """extract a single tree entry from a file list
+        
+        For use as a callback in get_tree_entry
+        raises 404 if not found
+        """
+        jsondata = response_text(tree_response)
+        data = json.loads(jsondata)
+        for entry in data['tree']:
+            if entry['path'] == path:
+                return entry
+        
+        raise HTTPError(404, "%s not found among %i files" % (path, len(data['tree'])))
+    
+    def get_tree_entry(self, user, repo, path, ref='master', callback=None, **kwargs):
+        """Get a single tree entry for a path
+        
+        Useful for finding the blob url for a given path.
+        """
+        # only need a recursive fetch if it's not in the top-level dir
+        if '/' in path:
+            kwargs['recursive'] = True
+        
+        f = Future()
+        def cb(response):
+            try:
+                tree_entry = self._extract_tree_entry(path, response)
+            except Exception as e:
+                f.set_exception(e)
+                return
+            if callback:
+                result = callback(tree_entry)
+            else:
+                result = tree_entry
+            f.set_result(result)
+        
+        self.get_tree(user, repo, ref=ref, callback=cb, **kwargs)
+        return f
     

--- a/nbviewer/tests/test_github.py
+++ b/nbviewer/tests/test_github.py
@@ -128,7 +128,6 @@ class GitHubTestCase(NBViewerTestCase):
         self.assertIn('global-exclude', r.text)
 
     def test_github_blob_redirect(self):
-        raise SkipTest("raw github no longer redirects to tree views")
         url = self.url("github/ipython/ipython/blob/rel-2.0.0/IPython")
         r = requests.get(url)
         self.assertEqual(r.status_code, 200)

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -5,6 +5,7 @@
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 
+import base64
 import cgi
 import re
 from subprocess import check_output
@@ -136,3 +137,21 @@ def ipython_info():
     except AttributeError:
         # IPython < 2.0
         return eval(sysinfo.sys_info())
+
+def base64_decode(s):
+    """unicode-safe base64
+    
+    base64 API only talks bytes
+    """
+    s = py3compat.cast_bytes(s)
+    decoded = base64.decodestring(s)
+    return decoded
+
+def base64_encode(s):
+    """unicode-safe base64
+    
+    base64 API only talks bytes
+    """
+    s = py3compat.cast_bytes(s)
+    encoded = base64.encodestring(s)
+    return encoded.decode('ascii')


### PR DESCRIPTION
instead of raw.githubusercontent

at the request of GitHub support.

This also fixes the blob->tree redirect, so that test is unskilled.

Still some testing to do before merge.
