### PR TITLE
remove `?create=1`

### DIFF
--- a/nbviewer/frontpage.json
+++ b/nbviewer/frontpage.json
@@ -24,7 +24,7 @@
     "links":[
       {
         "text": "Python for Signal Processing",
-        "target": "http://nbviewer.ipython.org/github/unpingco/Python-for-Signal-Processing/",
+        "target": "github/unpingco/Python-for-Signal-Processing/",
         "img": "/static/img/example-nb/python-signal.png"
       },
       {


### PR DESCRIPTION
This was added as a way to detect whether links come from the front page. It’s no longer necessary because we have an explicit list of those URLs in frontpage.json.

also makes the path to frontpage.json configurable, because why not?
