### PR TITLE
demote log of index access to debug-level

### DIFF
--- a/nbviewer/log.py
+++ b/nbviewer/log.py
@@ -19,7 +19,8 @@ def log_request(handler):
     """
     status = handler.get_status()
     request = handler.request
-    if status == 304 or (status < 300 and isinstance(handler, StaticFileHandler)):
+    if status == 304 or (status < 300 and isinstance(handler, StaticFileHandler)) \
+        or (status < 300 and request.uri == '/'):
         # static-file successes or any 304 FOUND are debug-level
         log_method = access_log.debug
     elif status < 400:


### PR DESCRIPTION
removes a bunch of '200 GET / (1ms)' from the log output
