### PR TITLE
avoid quote ':' for url with port num

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -508,13 +508,18 @@ class URLHandler(RenderingHandler):
     @gen.coroutine
     def get(self, secure, url):
         proto = 'http' + secure
-        
+
         if '/?' in url:
             url, query = url.rsplit('/?', 1)
         else:
             query = None
+
+        try:
+            netloc, path = url.split('/', 1)
+        except:
+            netloc, path = url, ''
         
-        remote_url = u"{}://{}".format(proto, quote(url))
+        remote_url = u"{}://{}/{}".format(proto, netloc, quote(path))
         if query:
             remote_url = remote_url + '?' + query
         if not url.endswith('.ipynb'):


### PR DESCRIPTION
When I render a url like 'http://hostname:port/example.ipynb', it will quote ':' character, so cannot found the url.

pls review this pr.
