### PR TITLE
Use CMD not ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN pip install -r requirements.txt
 EXPOSE 8080
  
 # To change the number of threads use
-# docker run -d -p 80:8080 nbviewer -e NBVIEWER_THREADS=4
+# docker run -d -e NBVIEWER_THREADS=4 -p 80:8080 nbviewer
 ENV NBVIEWER_THREADS 2
  
-ENTRYPOINT python -m nbviewer --port=8080 --threads=$NBVIEWER_THREADS
+CMD ["python","-m","nbviewer","--port=8080"]


### PR DESCRIPTION
ENTRYPOINT is meant for what shell invokes the CMD (default is `sh -c`). Client tools, for instance, could be set as entrypoint. Not the right thing for web apps though.

Now nbviewer is just the default command. This allows us to be able to run other commands (or variations on the nbviewer launch setup).
