### PR TITLE
Accept $NBCACHE_PORT as a memcache URL

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -100,10 +100,16 @@ def main():
     else:
         exporter = HTMLExporter(config=config, log=log.app_log)
         pool = ThreadPoolExecutor(options.threads)
-        
+
     memcache_urls = os.environ.get('MEMCACHIER_SERVERS',
         os.environ.get('MEMCACHE_SERVERS')
     )
+
+    # Handle linked Docker containers
+    if(os.environ.get('NBCACHE_PORT')):
+      tcp_memcache = os.environ.get('NBCACHE_PORT')
+      memcache_urls = tcp_memcache.split('tcp://')[1]
+
     if options.no_cache:
         log.app_log.info("Not using cache")
         cache = MockCache()


### PR DESCRIPTION
When linking to the memcached container, environment variables are populated with connection info. Example:

```
core@nbviewer ~ $ /usr/bin/docker run --rm --name nbviewer.1.service -P --link nbcache:nbcache ipython/nbviewer env
HOME=/
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=47013ea59ae8
NBCACHE_PORT=tcp://172.17.0.8:11211
NBCACHE_PORT_11211_TCP=tcp://172.17.0.8:11211
NBCACHE_PORT_11211_TCP_ADDR=172.17.0.8
NBCACHE_PORT_11211_TCP_PORT=11211
NBCACHE_PORT_11211_TCP_PROTO=tcp
NBCACHE_NAME=/nbviewer.1.service/nbcache
NBCACHE_ENV_LANGUAGE=en_US.UTF-8
NBCACHE_ENV_LANG=en_US.UTF-8
NBCACHE_ENV_LC_ALL=en_US.UTF-8
LANGUAGE=en_US.UTF-8
LANG=en_US.UTF-8
LC_ALL=en_US.UTF-8
NBVIEWER_THREADS=2
```

This just handles `NBCACHE_PORT` directly so we don't have to hack around to get the server list into `MEMCACHE_SERVERS`.
