### PR TITLE
MathJax CDN URL Update

### DIFF
--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -77,7 +77,7 @@
     {% if css_theme %}
         <link href="/static/css/theme/{{css_theme}}.css" rel="stylesheet">
     {% endif %}
-    <script src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"type="text/javascript">
+    <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"type="text/javascript">
     </script>
     <script type="text/javascript">
     init_mathjax = function() {


### PR DESCRIPTION
Fixes #322.

MathJax is now on their own URL.
