### PR TITLE
Fall back to UTF-8

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -865,7 +865,10 @@ class GitHubBlobHandler(RenderingHandler):
             try:
                 # filedata may be bytes, but we need text
                 if isinstance(filedata, bytes):
-                    nbjson = filedata.decode('ascii')
+                    try:
+                        nbjson = filedata.decode('ascii')
+                    except Exception as e:
+                        nbjson = filedata.decode('utf-8')
                 else:
                     nbjson = filedata
             except Exception as e:


### PR DESCRIPTION
Fixes #332.

It may be better to rely on UTF-8 as the encoding and fallback to ascii instead.

However, maybe there is a way to pull the encoding from GitHub.
