### PR TITLE
Just decode as utf-8

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -865,10 +865,7 @@ class GitHubBlobHandler(RenderingHandler):
             try:
                 # filedata may be bytes, but we need text
                 if isinstance(filedata, bytes):
-                    try:
-                        nbjson = filedata.decode('ascii')
-                    except Exception as e:
-                        nbjson = filedata.decode('utf-8')
+                    nbjson = filedata.decode('utf-8')
                 else:
                     nbjson = filedata
             except Exception as e:


### PR DESCRIPTION
As @minrk pointed out in #334, let's just use UTF-8 as the encoding for GitHub blobs.

After all, the [GitHub API for Blobs returns UTF-8](https://developer.github.com/v3/git/blobs/) by default (`base64` encoding handled prior).
