### PR TITLE
fix bogus error if indexing is not turned on

### DIFF
--- a/nbviewer/index.py
+++ b/nbviewer/index.py
@@ -23,9 +23,9 @@ class NoSearch(Indexer):
     def __init__(self):
         pass
 
-    def index_notebook(self, notebook_url, notebook_contents):
+    def index_notebook(self, notebook_url, notebook_contents, *args, **kwargs):
         app_log.debug("Totally not indexing \"{}\"".format(notebook_url))
-        pass
+
 
 class ElasticSearch(Indexer):
     def __init__(self, host="127.0.0.1", port=9200):


### PR DESCRIPTION
`RenderingHandler.finish_notebook` throws an error when run locally without an index - it hits the line `self.index.index_notebook(download_url, nb, public)` (at https://github.com/ipython/nbviewer/blob/25126b2b232c4ddeab792b96f646762301258b6d/nbviewer/handlers.py#L514) and barfs because `NoSearch.index_notebook` expects 3 arguments, not 4.

`NoSearch.index_notebook` should just happily accept any arguments passed, notify debug that it wont index, and not raise errors. This should be independent of the call signature.

An alternative fix for this is to actually require 4 arguments for subclasses of `Indexer` - right now `ElasticSearch` uses 4 arguments but the abstract base class only expects 3. I think this fix is a little more robust, though.
