### PR TITLE
NotImplementedException should be called NotImplementedError

### DIFF
--- a/nbviewer/index.py
+++ b/nbviewer/index.py
@@ -16,7 +16,7 @@ from elasticsearch import Elasticsearch
 
 class Indexer():
     def index_notebook(self, notebook_url, notebook_contents):
-        raise NotImplementedException("index_notebook not implemented")
+        raise NotImplementedError("index_notebook not implemented")
 
 
 class NoSearch(Indexer):


### PR DESCRIPTION
pretty self explanatory - `NotImplementedException` isn't its name in python 2.7, at least
