### PR TITLE
Link to developer.rackspace.com when linking Rackspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IPython Notebook Viewer
 
-IPython nbviewer is the web application behind [IPython Notebook Viewer](http://nbviewer.ipython.org), which is graciously hosted by [Rackspace](http://www.rackspace.com).
+IPython nbviewer is the web application behind [IPython Notebook Viewer](http://nbviewer.ipython.org), which is graciously hosted by [Rackspace](https://developer.rackspace.com/?nbviewer=awesome).
 
 Run this locally to get most of the features of nbviewer on your own network.
 

--- a/nbviewer/templates/faq.md
+++ b/nbviewer/templates/faq.md
@@ -56,8 +56,7 @@ notebook application.
 
 ### Where is this Notebook Viewer hosted?
 
-This Notebook Viewer instance is hosted on [Rackspace](http://rackspace.com), who kindly provide hosting for the IPython open source project.
-Thanks to Rackspace, we are able to operate nbconvert as a free service.
+This Notebook Viewer instance is hosted on [Rackspace](https://developer.rackspace.com/?nbviewer=awesome), who kindly provide hosting for the IPython open source project. Thanks to Rackspace, we are able to operate nbconvert as a free service.
 
 ### I want to remove/update a notebook from Notebook Viewer.
 

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -140,7 +140,7 @@
           </div>
 
           <div class="span4">
-            <p>Thanks to <a href="http://www.rackspace.com">Rackspace</a> for hosting.</p>
+            <p>Thanks to <a href="https://developer.rackspace.com/?nbviewer=awesome">Rackspace</a> for hosting.</p>
             <p>nbviewer GitHub <a href="https://github.com/ipython/nbviewer">repository</a>.</p>
             <p>nbviewer <a href="https://github.com/ipython/nbviewer/blob/master/LICENSE.txt" target="_blank">license</a>.</p>
           </div>


### PR DESCRIPTION
The main rackspace.com site is not nearly as developer centric as the developer site, so I'm proposing we change the link to point to Rackspace's developer site.
