### PR TITLE
update bokeh link to new repository

### DIFF
--- a/nbviewer/frontpage.json
+++ b/nbviewer/frontpage.json
@@ -54,7 +54,7 @@
       },
       {
         "text": "Interactive data visualization with Bokeh",
-        "target": "github/ContinuumIO/bokeh-notebooks/blob/master/index.ipynb",
+        "target": "github/bokeh/bokeh-notebooks/blob/master/index.ipynb",
         "img": "/static/img/example-nb/bokeh.png"
       },
       {


### PR DESCRIPTION
The Bokeh project has been moved to a new organization: https://github.com/bokeh/. 
I'm updating the link in the nbviewer home page.
