### PR TITLE
Icon consistency

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -662,7 +662,7 @@ class GistHandler(RenderingHandler):
                 e['name'] = file['filename']
                 if file['filename'].endswith('.ipynb'):
                     e['url'] = quote('/%s/%s' % (gist_id, file['filename']))
-                    e['class'] = 'icon-book'
+                    e['class'] = 'fa-book'
                     ipynbs.append(e)
                 else:
                     github_url = u"https://gist.github.com/{user}/{gist_id}#file-{clean_name}".format(
@@ -671,7 +671,7 @@ class GistHandler(RenderingHandler):
                         clean_name=clean_filename(file['filename']),
                     )
                     e['url'] = github_url
-                    e['class'] = 'icon-share'
+                    e['class'] = 'fa-share'
                     others.append(e)
 
             entries.extend(ipynbs)
@@ -812,23 +812,23 @@ class GitHubTreeHandler(BaseHandler):
                 user=user, repo=repo, ref=ref, path=file['path']
                 )
                 e['url'] = quote(e['url'])
-                e['class'] = 'icon-folder-open'
+                e['class'] = 'fa-folder-open'
                 dirs.append(e)
             elif file['name'].endswith('.ipynb'):
                 e['url'] = u'/github/{user}/{repo}/blob/{ref}/{path}'.format(
                 user=user, repo=repo, ref=ref, path=file['path']
                 )
                 e['url'] = quote(e['url'])
-                e['class'] = 'icon-book'
+                e['class'] = 'fa-book'
                 ipynbs.append(e)
             elif file['html_url']:
                 e['url'] = file['html_url']
-                e['class'] = 'icon-share'
+                e['class'] = 'fa-share'
                 others.append(e)
             else:
                 # submodules don't have html_url
                 e['url'] = ''
-                e['class'] = 'icon-folder-close'
+                e['class'] = 'fa-folder-close'
                 others.append(e)
 
 

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -92,9 +92,7 @@
       <div class="navbar-inner">
         <div class="container">
           <button type="button" class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
+            <span class="fa fa-bars"></span>
           </button>
           <div class="nav-collapse collapse">
             <ul class="nav">
@@ -109,7 +107,9 @@
             <ul class="nav pull-right"> 
               {% if github_url %}
               <li>
-                  <a href="{{github_url}}">View on GitHub</a>
+                  <a href="{{github_url}}" title="View on GitHub">
+                    <i class="fa fa-github fa-2x menu-icon"></i>
+                  </a>
               </li>
               {% endif %}
               {% block otherlinks %}

--- a/nbviewer/templates/tabular.html
+++ b/nbviewer/templates/tabular.html
@@ -12,21 +12,21 @@
 {% block entries %}
 {% for entry in entries %}
   {% block entry scoped %}
-  <tr><td><i class='{{entry.class}}'></i> <a href='{{entry.url}}'>{{entry.name}}</a></td></tr>
+  <tr><td><a href='{{entry.url}}'><i class='fa {{entry.class}} fa-fw'></i> {{entry.name}}</a></td></tr>
   {% endblock entry %}
 {% endfor %}
 {% endblock entries %}
 {% block page_links %}
   {% if prev_url or next_url %}
-  <tr><td class="page_links">
+  <tr><td class="page_links" colspan="4">
     {% if prev_url %}
-    <a href="{{prev_url}}">&lt; prev </a>
+    <a href="{{prev_url}}"><i class="fa fa-fw fa-angle-left"></i> prev</a>
     {% endif %}
     {% if next_url and prev_url %}
-    ...
+    &nbsp;...&nbsp;
     {% endif %}
     {% if next_url %}
-    <a href="{{next_url}}">next &gt;</a>
+    <a href="{{next_url}}">next <i class="fa fa-fw fa-angle-right"></i></a>
     {% endif %}
   </td></tr>
   {% endif %}

--- a/nbviewer/templates/treelist.html
+++ b/nbviewer/templates/treelist.html
@@ -51,20 +51,22 @@
             <tbody>
                 <tr><td>
                 {% if len(breadcrumbs) > 1 %}
-                    <a href='../'><i class='icon-backward'></i> ..</a>
+                    <a href='../'>
+                      <i class='fa fa-backward fa-fw'></i> ..
+                    </a>
                 {% else %}
                   <a href='/{{ tree_type | default('github') }}/{{user}}'>
-                    <i class='icon-backward'></i>
-                    {{user}}'s {{ tree_type | default('repositorie')}}s
+                    <i class='fa fa-backward fa-fw'></i> {{user}}'s 
+                    {{ tree_type | default('repositorie')}}s
                   </a>
                 {% endif %}
                 </td></tr>
                 {% for entry in entries %}
-                  <tr><td><i class='{{entry.class}}'></i>
+                  <tr><td>
                   {% if entry.url %}
                     <a href='{{entry.url}}'>
                   {% endif %}
-                      {{entry.name}}
+                    <i class='fa fa-fw {{entry.class}}'></i> {{entry.name}}
                   {% if entry.url %}
                     </a>
                   {% endif %}

--- a/nbviewer/templates/usergists.html
+++ b/nbviewer/templates/usergists.html
@@ -8,10 +8,12 @@
 {% endblock header_row %}
 {% block entry scoped %}
 <tr>
-  <td><i class='icon-book'></i> &nbsp;<a href='{{entry.id}}'>{{entry.id}}</a></td>
+  <td><a href='{{entry.id}}'>{{entry.id}}</a></td>
   <td>
     {% for notebook in entry.notebooks %}
-    <a href='{{entry.id}}/{{notebook}}'>{{notebook}}</a>
+    <a href='{{entry.id}}/{{notebook}}'>
+      <i class='fa fa-fw fa-book'></i> {{notebook}}
+    </a>
     {% endfor %}
   </td>
   <td>

--- a/nbviewer/templates/userview.html
+++ b/nbviewer/templates/userview.html
@@ -1,4 +1,8 @@
 {% extends "tabular.html" %}
 {% block entry scoped %}
-<tr><td><i class='icon-book'></i> <a href='{{entry.url}}'>{{entry.name}}</a></td></tr>
+<tr><td>
+  <a href='{{entry.url}}'>
+    <i class='fa fa-fw fa-book'></i> {{entry.name}}
+  </a>
+</td></tr>
 {% endblock entry %}


### PR DESCRIPTION
As per #359, this standardizes use of icons.
- always use font-awesome: shouldn't even load glyphicons...
- remove `&nbsp;`s, use `fa-fw` to ensure spacing
- put icons inside links if they are next to a link
- in tree, "view on github" change to icon, like on notebooks
- in table, in addition to fixing a minor template, move the icons to the notebook links to break up space... not totally committed to this, but it does help break up the stream of text which is actually separate links.

the test fail is somewhat strange: can't reproduce.

there are probably a few other stylistic choices that could be made to tighten the overall feel
- the `rewind` for `up directory` is somewhat non-standard...
- back to top of page icon...
- eventual `/format/` icons...
