### PR TITLE
Log the full error message body.

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -182,7 +182,7 @@ class BaseHandler(web.RequestHandler):
         else:
             msg = str_exc
 
-        app_log.warn("Fetching %s failed with %s", url, msg)
+        app_log.warn("Fetching %s failed with %s. Body=%s", url, msg, escape(body))
         if exc.code == 599:
             if isinstance(exc, CurlError):
                 en = getattr(exc, 'errno', -1)


### PR DESCRIPTION
Since we're getting intermittent 403s from GitHub, turn up our logging to see what GitHub is reporting back.
