### PR TITLE
Slim down the error body

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -182,7 +182,9 @@ class BaseHandler(web.RequestHandler):
         else:
             msg = str_exc
 
-        app_log.warn("Fetching %s failed with %s. Body=%s", url, msg, escape(body))
+        slim_body = body[:300].encode('string_escape')
+
+        app_log.warn("Fetching %s failed with %s. Body=%s", url, msg, slim_body)
         if exc.code == 599:
             if isinstance(exc, CurlError):
                 en = getattr(exc, 'errno', -1)


### PR DESCRIPTION
If we get a gigantic HTML 404 response, this would log a _lot_ to the log. Trim it down and escape it so it's all in one line.
