### PR TITLE
log GitHub rate limit

### DIFF
--- a/nbviewer/github.py
+++ b/nbviewer/github.py
@@ -72,7 +72,9 @@ class AsyncGitHubClient(object):
         limit_s = r.headers.get('X-RateLimit-Limit', '')
         remaining_s = r.headers.get('X-RateLimit-Remaining', '')
         if not remaining_s or not limit_s:
-            self.log.warn("No rate limit header. Did GitHub change?")
+            self.log.warn("No rate limit headers. Did GitHub change? %s",
+                json.dumps(r.headers, indent=1)
+            )
             return
         
         remaining = int(remaining_s)


### PR DESCRIPTION
debug-level most of the time
warn-level if less than 10% remains
error-level if limit is exceeded

should let us better diagnose rate-limiting issues
