### PR TITLE
fix a couple regressions in recent PRs

### DIFF
--- a/nbviewer/github.py
+++ b/nbviewer/github.py
@@ -72,9 +72,10 @@ class AsyncGitHubClient(object):
         limit_s = r.headers.get('X-RateLimit-Limit', '')
         remaining_s = r.headers.get('X-RateLimit-Remaining', '')
         if not remaining_s or not limit_s:
-            self.log.warn("No rate limit headers. Did GitHub change? %s",
-                json.dumps(r.headers, indent=1)
-            )
+            if r.code < 300:
+                app_log.warn("No rate limit headers. Did GitHub change? %s",
+                    json.dumps(r.headers, indent=1)
+                )
             return
         
         remaining = int(remaining_s)

--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -182,7 +182,7 @@ class BaseHandler(web.RequestHandler):
         else:
             msg = str_exc
 
-        slim_body = body[:300].encode('string_escape')
+        slim_body = escape(body[:300])
 
         app_log.warn("Fetching %s failed with %s. Body=%s", url, msg, slim_body)
         if exc.code == 599:


### PR DESCRIPTION
- str.encode('string_escape') doesn't exist in Python 3
- use app_log, not self.log in GitHubClient
- only warn about the absence of rate headers on successful requests (400 doesn't always include rate headers)

closes #385
