### PR TITLE
Build less

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get install -y -q python python-dev python-pip
 RUN apt-get install -y -q libzmq3-dev sqlite3 libsqlite3-dev pandoc libevent-dev libcurl4-openssl-dev libmemcached-dev nodejs nodejs-legacy npm
 
 # asset toolchain
-RUN npm install -g bower
+RUN npm install -g bower less
 
 # install IPython 2.x branch
 WORKDIR /srv
@@ -33,15 +33,15 @@ WORKDIR /srv/ipython
 RUN git submodule init && git submodule update
 RUN pip install .
 
+RUN pip install invoke
+
 ADD . /srv/nbviewer/
-
-WORKDIR /srv/nbviewer/nbviewer/static
-RUN bower install --config.interactive=false --allow-root
-
 WORKDIR /srv/nbviewer
+
+RUN invoke bower
+RUN invoke less
+
 RUN pip install -r requirements.txt
-
-WORKDIR /srv/nbviewer
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -77,14 +77,17 @@ pip install -r requirements.txt`
 
 #### Static Assets
 
-Static assets are maintained with `bower`.
+Static assets are maintained with `bower` and `less`.
 
 ```shell
 $ cd <path to repo>
 $ invoke bower
+$ invoke less [-d]
 ```
 
-This will download the relevant assets into `nbewier/static/components`.
+This will download the relevant assets into `nbviewer/static/components` and create the built assets in `nbviewer/static/build`.
+
+Pass `-d` or `--debug` to `invoke less` to create a CSS sourcemap, useful for debugging.
 
 
 #### Running Locally

--- a/nbviewer/static/less/notebook.less
+++ b/nbviewer/static/less/notebook.less
@@ -1,0 +1,29 @@
+@import (less) "style/ipython.min.css";
+
+// Fixes regression of #391 when using bower-pygments
+.highlight {
+  @import (less) "../components/pygments/css/default.css";
+}
+
+// from inline
+.imgwrap {
+  text-align: center;
+}
+
+@media screen and (min-width:980px) {
+  body {
+    padding-top: 40px;
+  }
+}
+
+@media (max-width: 767px) {
+  div.input, div.output_area {
+    -webkit-box-orient: vertical;
+    -moz-box-orient: vertical;
+    box-orient: vertical;
+  }
+
+  div.prompt {
+    text-align:left;
+  }
+}

--- a/nbviewer/static/less/styles.less
+++ b/nbviewer/static/less/styles.less
@@ -1,8 +1,8 @@
-@import (inline) "../css/docs.css";
+@import (less) "../css/docs.css";
 @import (inline) "../components/bootstrap/css/bootstrap.min.css";
-@import (inline) "../components/bootstrap/css/bootstrap-responsive.css";
-@import (inline) "../components/animate.css/animate.min.css";
+@import (less) "../components/bootstrap/css/bootstrap-responsive.css";
+@import (less) "../components/animate.css/animate.min.css";
 @import (less) "../components/font-awesome/less/font-awesome";
-@import (inline) "../css/nbviewer.css";
+@import (less) "../css/nbviewer.css";
 
 @import "variables";

--- a/nbviewer/static/less/styles.less
+++ b/nbviewer/static/less/styles.less
@@ -1,0 +1,8 @@
+@import (inline) "../css/docs.css";
+@import (inline) "../components/bootstrap/css/bootstrap.min.css";
+@import (inline) "../components/bootstrap/css/bootstrap-responsive.css";
+@import (inline) "../components/animate.css/animate.min.css";
+@import (less) "../components/font-awesome/less/font-awesome";
+@import (inline) "../css/nbviewer.css";
+
+@import "variables";

--- a/nbviewer/static/less/variables.less
+++ b/nbviewer/static/less/variables.less
@@ -1,0 +1,1 @@
+@fa-font-path: "../components/font-awesome/fonts";

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -54,12 +54,7 @@
     <!--NREND-->
 
     <!-- Le styles -->
-    <link href="/static/css/docs.css" rel="stylesheet">
-    <link href="/static/components/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/static/components/bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="/static/components/animate.css/animate.min.css" rel="stylesheet">
-    <link href="/static/components/font-awesome/css/font-awesome.min.css" rel="stylesheet">
-    <link href="/static/css/nbviewer.css" rel="stylesheet">
+    <link href="/static/build/styles.css" rel="stylesheet">
 
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->

--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -44,38 +44,9 @@
     {% endif %}
     #}
 
-    <link href="/ipython-static/style/ipython.min.css" rel="stylesheet">
-    <link href="/static/components/pygments/css/default.css" rel="stylesheet">
-    <style type="text/css" media='screen and (min-width:980px)'>
-   
-    body {
-        padding-top: 40px;
-    }
-
-    </style>
-    <style type="text/css" >
-    .imgwrap {
-        text-align: center;
-    }
-
-    @media (max-width: 767px){
-
-        div.input, div.output_area {
-            -webkit-box-orient: vertical;
-            -moz-box-orient: vertical;
-            box-orient: vertical;
-        }
-
-        div.prompt {
-            text-align:left;
-        }
-
-    }
-
-    
-    </style>
+    <link href="/static/build/notebook.css" rel="stylesheet">
     {% if css_theme %}
-        <link href="/static/css/theme/{{css_theme}}.css" rel="stylesheet">
+      <link href="/static/css/theme/{{css_theme}}.css" rel="stylesheet">
     {% endif %}
     <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"type="text/javascript">
     </script>

--- a/tasks.py
+++ b/tasks.py
@@ -16,11 +16,20 @@ def bower():
 
 
 @invoke.task
-def less():
-    tmpl = ("cd nbviewer/static/less && lessc --include-path={0} "
-            "{1}.less ../build/{1}.css")
+def less(debug=False):
+    if debug:
+        extra_args = "--source-map"
+    else:
+        extra_args = "--compress"
+
+    tmpl = (
+        "cd nbviewer/static/less && lessc {1} --include-path={2} "
+        "{0}.less ../build/{0}.css"
+    )
+
+    args = (extra_args, DEFAULT_STATIC_FILES_PATH)
 
     [
-        invoke.run(tmpl.format(DEFAULT_STATIC_FILES_PATH, less_file))
+        invoke.run(tmpl.format(less_file, *args))
         for less_file in ["styles", "notebook"]
     ]

--- a/tasks.py
+++ b/tasks.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import invoke
-
+from IPython.html import DEFAULT_STATIC_FILES_PATH
 
 @invoke.task
 def test():
@@ -11,4 +11,16 @@ def test():
 
 @invoke.task
 def bower():
-    invoke.run("cd nbviewer/static && bower install")
+    invoke.run("cd nbviewer/static && "
+               "bower install --config.interactive=false --allow-root")
+
+
+@invoke.task
+def less():
+    tmpl = ("cd nbviewer/static/less && lessc --include-path={0} "
+            "{1}.less ../build/{1}.css")
+
+    [
+        invoke.run(tmpl.format(DEFAULT_STATIC_FILES_PATH, less_file))
+        for less_file in ["styles", "notebook"]
+    ]


### PR DESCRIPTION
This adds LESS to build, combine and compress the CSS assets. It fixes #391, and reduces the number of  requests by a fair amont:
![screenshot from 2015-01-10 18 14 00](https://cloud.githubusercontent.com/assets/45380/5693651/84508712-98f4-11e4-8881-9f0eb28140a2.png)

There is a new invoke task: `invoke less`. It can generate source maps.

This combines all of the CSS from `layout.html` into `static/build/styles.css` and all of the CSS from `notebook.html` into `static/build/notebook.css`.

Wherever possible, the existing CSS is being interpreted as LESS, so it can be compressed when served.

The Dockerfile now uses the invoke tasks.