### PR TITLE
List Fastly as a sponsor

### DIFF
--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -139,9 +139,8 @@
           </div>
 
           <div class="span4">
-            <p>Thanks to <a href="https://developer.rackspace.com/?nbviewer=awesome">Rackspace</a> for hosting.</p>
+            <p>Delivered by <a href="http://www.fastly.com/">Fastly</a>, Rendered by <a href="https://developer.rackspace.com/?nbviewer=awesome">Rackspace</a></p>
             <p>nbviewer GitHub <a href="https://github.com/jupyter/nbviewer">repository</a>.</p>
-            <p>nbviewer <a href="https://github.com/jupyter/nbviewer/blob/master/LICENSE.txt" target="_blank">license</a>.</p>
           </div>
 
           <div class="span4">


### PR DESCRIPTION
Closes #397, adding Fastly as a sponsor.

I also took a redundant bit about the license in the footer which can also be found in the repo itself. I'd really like to get this footer cleaned up a bit more but this is it for now.

/cc @ejgreenberg