### PR TITLE
Accept GitHub branch/tags with slashes

### DIFF
--- a/nbviewer/providers/github/tests/test_github.py
+++ b/nbviewer/providers/github/tests/test_github.py
@@ -145,6 +145,13 @@ class GitHubTestCase(NBViewerTestCase):
         # verify tag is linked
         self.assertIn('/github/ipython/ipython/tree/rel-2.3.0/', html)
 
+    def test_github_slash_ref_blob(self):
+        url = self.url(
+            '/github/remram44/ipython-nbviewer/blob/wrong/branch/test.ipynb'
+        )
+        r = requests.get(url)
+        self.assertEqual(r.status_code, 200)
+
 
 class FormatHTMLGitHubTestCase(NBViewerTestCase, FormatHTMLMixin):
     pass

--- a/nbviewer/templates/treelist.html
+++ b/nbviewer/templates/treelist.html
@@ -17,10 +17,10 @@
 {% endmacro %}
 
 
-{% macro ref_dropdown(current, branches, tags) -%}
+{% macro ref_dropdown(current, symbolic_ref, branches, tags) -%}
   <div class="pull-right dropdown dropdown-ref">
     <a class="dropdown-toggle" data-toggle="dropdown">
-      {{ current }}
+      {{ symbolic_ref|default(current) }}
     </a>
     <div class="dropdown-menu" role="menu">
       <div class="container-fluid">
@@ -38,7 +38,7 @@
   <div>
     {% if branches|length + tags|length > 1 %}
       <div class="breadcrumb pull-right">
-        {{ ref_dropdown(ref, branches, tags) }}
+        {{ ref_dropdown(ref, symbolic_ref, branches, tags) }}
       </div>
     {% endif %}
 
@@ -58,7 +58,7 @@
             </a>
           {% else %}
             <a href="/{{ tree_type }}/{{user}}">
-              <i class="fa fa-backward fa-fw"></i> {{user}}'s 
+              <i class="fa fa-backward fa-fw"></i> {{user}}'s
               {{ tree_type | default('repositorie')}}s
             </a>
           {% endif %}


### PR DESCRIPTION
This proposes one approach to accepting refs that contain slashes, as in #409. Github accepts these on their public URL scheme, but not on their API, which actually wants SHAs... though it does support "normal", non-slashed refs, which has created this whole expectation.

This approach pulls down the tags and branches, and checks them for the first matching name, then replaces the `ref` with the SHA of the first named ref. Because of this, we will likely want to revisit caching the upstream API calls, as now any 404 is much more expensive.

While it's not possible for one slashed ref name to be contained in another (because they map to files in `.git`), it probably WOULD be possible for some combination of ref + path...
- this
  - ref `foo/bar`
  - path `baz`
- that
  - ref `foo`
  - path `bar/baz`

... but now you're just being evil.

There is still some work to do, as it changes the refs in-line to minimize total changes. The tree view, for example, now shows the SHA instead of the symbolic name, which is ugly. Wanted to get this out there in the meantime.