### PR TITLE
Use IPython 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,11 @@ before_install:
 install:
 - pip install -r requirements.txt
 - invoke bower
+- invoke less
 script: invoke test
+cache:
+  apt: true
+  pip: true
 env:
   global:
   - secure: Sv53YMdsVTin1hUPRqIuvdAOJ0UwklEowW49qpxY9wSgiAM79D+e1b5Yxrn+RTtS3WGlvK1aKHICc+2ajccEJkKFL8WDy2SnTnoWPadrEy4NAGLkNMGK+bAYMnLNoNRbSGVz5JpvNJ7JkeaEplhJ572OJOxa1X7ZF9165ZbOWng=

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ script: invoke test
 cache:
   apt: true
   pip: true
+  directories:
+    - /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages
 env:
   global:
   - secure: Sv53YMdsVTin1hUPRqIuvdAOJ0UwklEowW49qpxY9wSgiAM79D+e1b5Yxrn+RTtS3WGlvK1aKHICc+2ajccEJkKFL8WDy2SnTnoWPadrEy4NAGLkNMGK+bAYMnLNoNRbSGVz5JpvNJ7JkeaEplhJ572OJOxa1X7ZF9165ZbOWng=

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ install:
 - invoke bower
 - invoke less
 script: invoke test
-cache:
-  apt: true
-  pip: true
-  directories:
-    - /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages
 env:
   global:
   - secure: Sv53YMdsVTin1hUPRqIuvdAOJ0UwklEowW49qpxY9wSgiAM79D+e1b5Yxrn+RTtS3WGlvK1aKHICc+2ajccEJkKFL8WDy2SnTnoWPadrEy4NAGLkNMGK+bAYMnLNoNRbSGVz5JpvNJ7JkeaEplhJ572OJOxa1X7ZF9165ZbOWng=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 - sudo apt-get install -qq libzmq3-dev pandoc libcurl4-gnutls-dev libmemcached-dev
 - pip install -U setuptools
 - pip install -r dev-requirements.txt
-- npm install -g bower
+- npm install -g bower less
 install:
 - pip install -r requirements.txt
 - invoke bower

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN npm install -g bower less
 
 # install IPython 2.x branch
 WORKDIR /srv
-RUN git clone --depth 1 -b 2.x https://github.com/ipython/ipython.git
+RUN git clone --depth 1 -b 3.x https://github.com/ipython/ipython.git
 WORKDIR /srv/ipython
 RUN git submodule init && git submodule update
 RUN pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,15 +35,19 @@ RUN pip install .
 
 RUN pip install invoke
 
-ADD . /srv/nbviewer/
+ADD ./requirements.txt /srv/nbviewer/
 WORKDIR /srv/nbviewer
-
-RUN invoke bower
-RUN invoke less
 
 RUN pip install -r requirements.txt
 
+ADD ./tasks.py /srv/nbviewer/
+ADD ["/nbviewer/static/bower.json", "/nbviewer/static/.bowerrc", "/srv/nbviewer/nbviewer/static/"]
+RUN invoke bower
+
 EXPOSE 8080
+
+ADD . /srv/nbviewer/
+RUN invoke less
 
 # To change the number of threads use
 # docker run -d -e NBVIEWER_THREADS=4 -p 80:8080 nbviewer

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ WORKDIR /srv/nbviewer
 RUN pip install -r requirements.txt
 
 ADD ./tasks.py /srv/nbviewer/
-ADD ["/nbviewer/static/bower.json", "/nbviewer/static/.bowerrc", "/srv/nbviewer/nbviewer/static/"]
+ADD ["./nbviewer/static/bower.json", "./nbviewer/static/.bowerrc", \   
+     "/srv/nbviewer/nbviewer/static/"]
 RUN invoke bower
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /srv
 RUN git clone --depth 1 -b 3.x https://github.com/ipython/ipython.git
 WORKDIR /srv/ipython
 RUN git submodule init && git submodule update
-RUN pip install .
+RUN pip install -e .[notebook]
 
 RUN pip install invoke
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ docker build -t nbviewer .
 docker run -p 8080:8080 nbviewer
 ```
 
+### With Docker Compose
+
+The Notebook Viewer uses `memcache` in production. To locally try out this
+setup, a [docker-compose](https://docs.docker.com/compose/) configuration is
+provided to easily start/stop the `nbviewer` and `memcache` containers together:
+
+#### Run
+
+```shell
+docker-compose up
+```
+
 
 ### Local Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+nbviewer:
+  build: .
+  links:
+  - nbcache
+  command: python -m nbviewer --port=8080
+  ports:
+   - 8080:8080
+nbcache:
+  image: memcached

--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -39,7 +39,7 @@ except ImportError:
     class CurlError(Exception): pass
 
 from IPython.html import DEFAULT_STATIC_FILES_PATH as ipython_static_path
-from IPython.nbformat.current import reads_json
+from IPython.nbformat import reads, current_nbformat
 
 from .render import render_notebook, NbFormatError
 from .utils import (transform_ipynb_uri, quote, response_text, base64_decode,
@@ -503,7 +503,7 @@ class RenderingHandler(BaseHandler):
             msg = download_url
 
         try:
-            nb = reads_json(json_notebook)
+            nb = reads(json_notebook, current_nbformat)
         except ValueError:
             app_log.error("Failed to render %s", msg, exc_info=True)
             raise web.HTTPError(400, "Error reading JSON notebook")

--- a/nbviewer/render.py
+++ b/nbviewer/render.py
@@ -6,7 +6,6 @@
 #-----------------------------------------------------------------------------
 
 from tornado.log import app_log
-from IPython.nbformat.current import reads_json
 from IPython.nbconvert.exporters import Exporter
 
 #-----------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ pycurl
 pylibmc
 futures
 newrelic
+markdown
 elasticsearch
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ newrelic
 markdown
 elasticsearch
 
-
-IPython[notebook]>=3.0.0
+ipython[notebook]>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,8 @@
-tornado>=3.1.1
 pycurl
 pylibmc
 futures
 newrelic
-markdown
 elasticsearch
 
-pygments
-jinja2
 
-ipython>=2.0.0
+IPython[notebook]>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+tornado>=3.1.1
+
 pycurl
 pylibmc
 futures

--- a/tasks.py
+++ b/tasks.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 import invoke
 from IPython.html import DEFAULT_STATIC_FILES_PATH
+
+
+APP_ROOT = os.path.dirname(__file__)
+
 
 @invoke.task
 def test():
@@ -11,7 +16,7 @@ def test():
 
 @invoke.task
 def bower():
-    invoke.run("cd nbviewer/static && "
+    invoke.run("cd {}/nbviewer/static && ".format(APP_ROOT,) +
                "bower install --config.interactive=false --allow-root")
 
 
@@ -23,7 +28,8 @@ def less(debug=False):
         extra_args = "--compress"
 
     tmpl = (
-        "cd nbviewer/static/less && lessc {1} --include-path={2} "
+        "cd {}/nbviewer/static/less ".format(APP_ROOT,) +
+        "&& lessc {1} --include-path={2} "
         "{0}.less ../build/{0}.css"
     )
 


### PR DESCRIPTION
Hooray IPython 3.0 :cake:! Welcome to the future :monorail:!

This upgrades nbviewer's IPython requirement to `IPython[notebook]>=3.0`.

Since all good things come in threes, I'd love to see (IPython, Bootstrap & Reveal (ahem, #390)) 3.x all wrapped up as a 0.3.0 release!