### PR TITLE
Added ability to use a web proxy.

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -79,6 +79,8 @@ def main():
     define("sslcert", help="path to ssl .crt file", type=str)
     define("sslkey", help="path to ssl .key file", type=str)
     define("default_format", default="html", help="format to use for legacy / URLs", type=str)
+    define("proxy_host", default="", help="The proxy URL.", type=str)
+    define("proxy_port", default="", help="The proxy port.", type=int)
     tornado.options.parse_command_line()
 
     # NBConvert config
@@ -199,6 +201,14 @@ def main():
         for link in section['links']:
             max_cache_uris.add('/' + link['target'])
 
+    fetch_kwargs = dict(connect_timeout=10,)
+    if options.proxy_host: 
+        fetch_kwargs.update(dict(proxy_host=options.proxy_host,
+                                 proxy_port=options.proxy_port))
+
+        log.app_log.info("Using web proxy {proxy_host}:{proxy_port}."
+                         "".format(**fetch_kwargs))
+
     settings = dict(
         log_function=log_request,
         jinja2_env=env,
@@ -218,9 +228,7 @@ def main():
         gzip=True,
         render_timeout=20,
         localfile_path=os.path.abspath(options.localfiles),
-        fetch_kwargs=dict(
-            connect_timeout=10,
-        ),
+        fetch_kwargs=fetch_kwargs,
     )
 
     # handle handlers

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 import sys
 pjoin = os.path.join
 
-from distutils.core import setup
+from setuptools import setup
 
 def walk_subpkg(name):
     data_files = []


### PR DESCRIPTION
OK, time to come clean... I've had several local patches which make using the nbviewer as an internal service easier sitting on my machine for the last ~12 months.

The first is this one - the ability to use web proxies.

I've also slipped in the use of setuptools rather than distutils... slightly controversial, but let's move with the times... :wink: - I'd be happy to revert, it is just it makes working with the source easier as you can do ``python setup.py develop`` (simple things).