### PR TITLE
Test json files

### DIFF
--- a/nbviewer/frontpage.json
+++ b/nbviewer/frontpage.json
@@ -46,7 +46,7 @@
         "text": "Data Visualization with Lightning",
         "target": "github/lightning-viz/lightning-example-notebooks/blob/master/index.ipynb",
         "img": "/static/img/example-nb/lightning.png"
-      }
+      },
       {
         "text": "Interactive data visualization with Bokeh",
         "target": "github/bokeh/bokeh-notebooks/blob/master/index.ipynb",

--- a/nbviewer/frontpage.schema.json
+++ b/nbviewer/frontpage.schema.json
@@ -1,0 +1,25 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "header": {"type": "string"},
+      "links": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "text": {"type": "string"},
+            "target": {"type": "string"},
+            "img": {"type": "string"}
+          },
+          "required": ["text", "target", "img"]
+        }
+      }
+    },
+    "required": [
+      "header",
+      "links"
+    ]
+  }
+}

--- a/nbviewer/tests/test_json.py
+++ b/nbviewer/tests/test_json.py
@@ -2,17 +2,44 @@ import os
 import json
 from unittest import TestCase
 
+from jsonschema import validate
+
+
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 
 class JSONTestCase(TestCase):
-    json = "nbviewer/frontpage.json"
+    json = None
+    schema = None
 
     def test_json(self):
+        if not self.json:
+            return
+
         try:
             json.load(open(os.path.join(ROOT, self.json), "r"))
         except Exception as err:
             self.fail("%s failed to parse:  %s" % (self.json, err))
+
+    def test_schema(self):
+        if not self.schema:
+            return
+
+        try:
+            data = json.load(open(os.path.join(ROOT, self.json), "r"))
+            schema = json.load(open(os.path.join(ROOT, self.schema), "r"))
+            validate(data, schema)
+        except Exception as err:
+            self.fail("%s failed to validate against %s:  %s" % (
+                self.json,
+                self.schema,
+                err
+            ))
+
+
+class FrontpageJSONTestCase(JSONTestCase):
+    json = "nbviewer/frontpage.json"
+    schema = "nbviewer/frontpage.schema.json"
 
 
 class BowerJSONTestCase(JSONTestCase):

--- a/nbviewer/tests/test_json.py
+++ b/nbviewer/tests/test_json.py
@@ -1,0 +1,27 @@
+import os
+import json
+from unittest import TestCase
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+class JSONTestCase(TestCase):
+    json = "nbviewer/frontpage.json"
+
+    def test_json(self):
+        try:
+            json.load(open(os.path.join(ROOT, self.json), "r"))
+        except Exception as err:
+            self.fail("%s failed to parse:  %s" % (self.json, err))
+
+
+class BowerJSONTestCase(JSONTestCase):
+    json = "nbviewer/static/bower.json"
+
+
+class BowerRcJSONTestCase(JSONTestCase):
+    json = "nbviewer/static/.bowerrc"
+
+
+class NpmJSONTestCase(JSONTestCase):
+    json = "package.json"


### PR DESCRIPTION
This adds tests for well-formedness of JSON files that are part of the project, and fixes the invalid `frontpage.json` from #424. Instead of just parsing every JSON file in the project (think `node_modules`), I've just ticked them off explicitly.

`package.json` and `bower.json` are basically impossible to validate, but since we already have `jsonschema` around from IPython, I have added a schema for the front page. This should give us some good assurance of avoiding surprises in the future. Or something.