### PR TITLE
Docker: FROM ipython/ipython:3.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,15 @@
 # Using the Ubuntu image
-FROM ubuntu:14.04
+FROM ipython/ipython:3.x
 
 MAINTAINER IPython Project <ipython-dev@scipy.org>
 
-# Make sure apt is up to date
-RUN apt-get update
-RUN apt-get upgrade -y
+RUN apt-get install -y -q \
+  libmemcached-dev
 
-# Not essential, but wise to set the lang
-RUN apt-get install -y language-pack-en
-ENV LANGUAGE en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-
-RUN locale-gen en_US.UTF-8
-RUN dpkg-reconfigure locales
-
-# Python binary dependencies, developer tools
-RUN apt-get install -y -q build-essential make gcc zlib1g-dev git
-RUN apt-get install -y -q python python-dev python-pip
-
-# nbviewer binary dependencies
-RUN apt-get install -y -q libzmq3-dev sqlite3 libsqlite3-dev pandoc libevent-dev libcurl4-openssl-dev libmemcached-dev nodejs nodejs-legacy npm
-
-# install IPython 3.x branch
-WORKDIR /srv
-RUN git clone --depth 1 -b 3.x https://github.com/ipython/ipython.git
-WORKDIR /srv/ipython
-RUN git submodule init && git submodule update
-RUN pip install -e .[notebook]
+# To change the number of threads use
+# docker run -d -e NBVIEWER_THREADS=4 -p 80:8080 nbviewer
+ENV NBVIEWER_THREADS 2
+EXPOSE 8080
 
 RUN pip install invoke
 WORKDIR /srv/nbviewer
@@ -42,19 +23,13 @@ RUN pip install -r requirements.txt
 
 ADD ./tasks.py /srv/nbviewer/
 
-ADD ["./nbviewer/static/bower.json", "./nbviewer/static/.bowerrc", \   
+ADD ["./nbviewer/static/bower.json", "./nbviewer/static/.bowerrc", \
      "/srv/nbviewer/nbviewer/static/"]
 RUN invoke bower
-
-EXPOSE 8080
 
 ADD . /srv/nbviewer/
 RUN invoke less
 
-# To change the number of threads use
-# docker run -d -e NBVIEWER_THREADS=4 -p 80:8080 nbviewer
-ENV NBVIEWER_THREADS 2
-
 USER nobody
 
-CMD ["python","-m","nbviewer","--port=8080"]
+CMD ["python", "-m", "nbviewer", "--port=8080"]


### PR DESCRIPTION
Deployment is getting a little behind IPython 3.x master. With the big split is coming, this might be the best way to have an image that is close to what is expected by upstream development.

Also some little movements of things that don't change much and were pretty late in the build.

And whitespace. Always whitespace.

@rgbkrk what were your reasons for not wanting to do this earlier?