### PR TITLE
Restoring scrollable long slides

### DIFF
--- a/nbviewer/static/less/slides.less
+++ b/nbviewer/static/less/slides.less
@@ -4,7 +4,7 @@
 /* Overrides of notebook CSS for static HTML export */
 body {
   overflow-x: hidden;
-  /* overflow-y modified at reveal.css */
+  overflow-y: auto;
   line-height: inherit;
 }
 

--- a/nbviewer/templates/formats/slides.html
+++ b/nbviewer/templates/formats/slides.html
@@ -35,7 +35,7 @@
 {% endblock %}
 
 
-{% block body %}
+{% block container %}
   {{ body|safe }}
 
   <script>
@@ -93,4 +93,4 @@
       }
     );//require
   </script>
-{% endblock %}
+{% endblock container %}

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -115,7 +115,7 @@
     </div>
   </nav>
 
-  <div class="container">
+  {% block container %}<div class="container">
     {% block body %}{% endblock %}
 
     <div class="back-to-top hidden-print text-center">
@@ -157,7 +157,7 @@
       </footer>
     {% endblock footer %}
 
-  </div><!-- /container -->
+  </div>{% endblock container %}
 
   <script src="/static/components/bootstrap/js/bootstrap.min.js"></script>
   <script src="/static/components/headroom.js/dist/headroom.min.js"></script>


### PR DESCRIPTION
This attempts to fix #433.

This solution is simple...
```css
body {overflow-y: auto}
```
...but is not ideal:
- it clobbers mobile UI swiping navigation between cells (and sub-cells)
  - this really bothers me, because reveal is actually really nice on mobile. see below...
- because there is _always_ a scrollbar on the screen (if you use sub-cells, or have any long slides) you can never tell whether there _actually is_ somewhere to scroll.

However, other related solutions (i.e. making the `section` scrollable) ended up with scrollbars in the middle of the page, and much, much worse on mobile. reveal just looks too much at the DOM.

In the future :monorail:, with either nbconvert or nbviewer respecting more of reveal's options in notebook metadata, I recommend we peg this to the opposite of the `touch` option:
```javascript
    // Enables touch navigation on devices with touch input
    touch: true,
```
as they will never be compatible. And since mobile support is good, and printing is good, I think it should be enabled by default... making "long slides" disabled by default. But in the future. But today, we scroll.

@damianavila @damontallen et al from #433, if you have any insights into what you think about this approach, any feedback is appreciated!