### PR TITLE
adding providers to pkg_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,12 @@ def walk_subpkg(name):
     return data_files
 
 pkg_data = {
-    "nbviewer": ['frontpage.json'] + walk_subpkg('static') + walk_subpkg('templates')
+    "nbviewer": (
+        ['frontpage.json'] +
+        walk_subpkg('static') +
+        walk_subpkg('templates') +
+        walk_subpkg('providers')
+    )
 }
 
 setup_args = dict(


### PR DESCRIPTION
This fixes #448 by adding `providers` to `pkg_data`.

Props to @shmilee for reporting. As an aside: how did this bite you? I am a relative newcomer to the black arts of serious setup.py sorcery.