### PR TITLE
[wip] Adding Github Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You must also specify your `OAUTH` or `API_TOKEN` as explained above.  For examp
 ```shell
 $ docker run -p 8080:8080 -e 'GITHUB_OAUTH_KEY=YOURKEY' \
                           -e 'GITHUB_OAUTH_SECRET=YOURSECRET' \
-                          -e 'GITHUB_API_URL=https://ghe.example.com/api/v3/' \
+                          -e 'GITHUB_API_URL=https://ghe.example.com/api/v3' \
                           jupyter/nbviewer
 ```
 
@@ -70,7 +70,7 @@ $ docker run -p 8080:8080 nbviewer
 
 The Notebook Viewer uses `memcached` in production. To locally try out this
 setup, a [docker-compose](https://docs.docker.com/compose/) configuration is
-provided to easily start/stop the `nbviewer` and `memcached` containers 
+provided to easily start/stop the `nbviewer` and `memcached` containers
 together from a your current branch. You will need to install `docker` prior
 to this.
 
@@ -124,7 +124,7 @@ This will automatically relaunch the server if a change is detected on a python 
 #### Running the Tests
 
 `nose` is used to run the test suite. The tests currently make calls to
-external APIs such as GitHub, so it is best to use your Github API Token when 
+external APIs such as GitHub, so it is best to use your Github API Token when
 running:
 
 ```shell
@@ -180,6 +180,6 @@ Formats are ways to present notebooks to the user.
 - `slides`
 
 #### Writing a new Format
-If you'd like to write a new format, open a ticket, or speak up on [gitter][]! 
-We have some work yet to do to support your next big thing in notebook 
+If you'd like to write a new format, open a ticket, or speak up on [gitter][]!
+We have some work yet to do to support your next big thing in notebook
 publishing, and we'd love to here from you.

--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -186,7 +186,7 @@ def main():
             max_cache_uris.add('/' + link['target'])
 
     fetch_kwargs = dict(connect_timeout=10,)
-    if options.proxy_host: 
+    if options.proxy_host:
         fetch_kwargs.update(dict(proxy_host=options.proxy_host,
                                  proxy_port=options.proxy_port))
 

--- a/nbviewer/providers/ghe/__init__.py
+++ b/nbviewer/providers/ghe/__init__.py
@@ -1,0 +1,4 @@
+from .handlers import (
+    default_handlers,
+    uri_rewrites,
+)

--- a/nbviewer/providers/ghe/client.py
+++ b/nbviewer/providers/ghe/client.py
@@ -2,7 +2,4 @@ from ..github.client import AsyncGitHubClient
 
 
 class AsyncGHEClient(AsyncGitHubClient):
-    API_URL_ENV = ('GHE_API_URL', '')
-    OAUTH_KEY_ENV = ('GHE_OAUTH_KEY', '')
-    OAUTH_SECRET_ENV = ('GHE_OAUTH_SECRET', '')
-    OAUTH_TOKEN_ENV = ('GHE_API_TOKEN', '')
+    ENV_PREFIX = 'GHE_'

--- a/nbviewer/providers/ghe/handlers.py
+++ b/nbviewer/providers/ghe/handlers.py
@@ -1,0 +1,67 @@
+import os
+
+from ..github import handlers as ghh
+
+PROVIDER_URL_FRAG = os.environ.get("GHE_PROVIDER_URL_FRAG", "ghe")
+HTML_URL = os.environ.get("GITHUB_HTML_URL", None)
+
+
+class GithubEnterpriseMixin(object):
+    PROVIDER_URL_FRAG = PROVIDER_URL_FRAG
+
+
+class AddSlashHandler(ghh.AddSlashHandler, GithubEnterpriseMixin):
+    pass
+
+
+class GitHubUserHandler(ghh.GitHubUserHandler, GithubEnterpriseMixin):
+    pass
+
+
+class GitHubRepoHandler(ghh.GitHubRepoHandler, GithubEnterpriseMixin):
+    pass
+
+
+class RemoveSlashHandler(ghh.RemoveSlashHandler, GithubEnterpriseMixin):
+    pass
+
+
+class GitHubBlobHandler(ghh.GitHubBlobHandler, GithubEnterpriseMixin):
+    pass
+
+
+class GitHubTreeHandler(ghh.GitHubTreeHandler, GithubEnterpriseMixin):
+    pass
+
+
+def default_handlers(handlers=[]):
+    """Tornado handlers"""
+
+    return handlers + [
+        (r'/{}/([^\/]+)'.format(PROVIDER_URL_FRAG),
+            AddSlashHandler),
+        (r'/{}/([^\/]+)/'.format(PROVIDER_URL_FRAG),
+            GitHubUserHandler),
+        (r'/{}/([^\/]+)/([^\/]+)'.format(PROVIDER_URL_FRAG),
+            AddSlashHandler),
+        (r'/{}/([^\/]+)/([^\/]+)/'.format(PROVIDER_URL_FRAG),
+            GitHubRepoHandler),
+        (r'/{}/([^\/]+)/([^\/]+)/blob/([^\/]+)/(.*)/'.format(PROVIDER_URL_FRAG),
+            RemoveSlashHandler),
+        (r'/{}/([^\/]+)/([^\/]+)/blob/([^\/]+)/(.*)'.format(PROVIDER_URL_FRAG),
+            GitHubBlobHandler),
+        (r'/{}/([^\/]+)/([^\/]+)/tree/([^\/]+)'.format(PROVIDER_URL_FRAG),
+            AddSlashHandler),
+        (r'/{}/([^\/]+)/([^\/]+)/tree/([^\/]+)/(.*)'.format(PROVIDER_URL_FRAG),
+            GitHubTreeHandler)
+    ]
+
+def uri_rewrites(rewrites=[]):
+    return rewrites + [
+        (HTML_URL + r'^([\w\-]+)/([^\/]+)/(blob|tree)/(.*)$',
+            u'/' + PROVIDER_URL_FRAG + u'/{0}/{1}/{2}/{3}'),
+        (r'^([\w\-]+)/([^\/]+)$',
+            u'/' + PROVIDER_URL_FRAG + u'/{0}/{1}/tree/master/'),
+        (r'^([\w\-]+)$',
+            u'/' + PROVIDER_URL_FRAG + u'/{0}/'),
+    ]

--- a/nbviewer/providers/ghe/handlers.py
+++ b/nbviewer/providers/ghe/handlers.py
@@ -58,7 +58,7 @@ def default_handlers(handlers=[]):
 
 def uri_rewrites(rewrites=[]):
     return rewrites + [
-        (r'^' + HTML_URL + r'([\w\-]+)/([^\/]+)/(blob|tree)/(.*)$',
+        (r'^' + HTML_URL + r'/([\w\-]+)/([^\/]+)/(blob|tree)/(.*)$',
             u'/' + PROVIDER_URL_FRAG + u'/{0}/{1}/{2}/{3}'),
         (r'^([\w\-]+)/([^\/]+)$',
             u'/' + PROVIDER_URL_FRAG + u'/{0}/{1}/tree/master/'),

--- a/nbviewer/providers/ghe/handlers.py
+++ b/nbviewer/providers/ghe/handlers.py
@@ -10,27 +10,27 @@ class GithubEnterpriseMixin(object):
     PROVIDER_URL_FRAG = PROVIDER_URL_FRAG
 
 
-class AddSlashHandler(ghh.AddSlashHandler, GithubEnterpriseMixin):
+class AddSlashHandler(GithubEnterpriseMixin, ghh.AddSlashHandler):
     pass
 
 
-class GitHubUserHandler(ghh.GitHubUserHandler, GithubEnterpriseMixin):
+class GitHubUserHandler(GithubEnterpriseMixin, ghh.GitHubUserHandler):
     pass
 
 
-class GitHubRepoHandler(ghh.GitHubRepoHandler, GithubEnterpriseMixin):
+class GitHubRepoHandler(GithubEnterpriseMixin, ghh.GitHubRepoHandler):
     pass
 
 
-class RemoveSlashHandler(ghh.RemoveSlashHandler, GithubEnterpriseMixin):
+class RemoveSlashHandler(GithubEnterpriseMixin, ghh.RemoveSlashHandler):
     pass
 
 
-class GitHubBlobHandler(ghh.GitHubBlobHandler, GithubEnterpriseMixin):
+class GitHubBlobHandler(GithubEnterpriseMixin, ghh.GitHubBlobHandler):
     pass
 
 
-class GitHubTreeHandler(ghh.GitHubTreeHandler, GithubEnterpriseMixin):
+class GitHubTreeHandler(GithubEnterpriseMixin, ghh.GitHubTreeHandler):
     pass
 
 
@@ -58,7 +58,7 @@ def default_handlers(handlers=[]):
 
 def uri_rewrites(rewrites=[]):
     return rewrites + [
-        (HTML_URL + r'^([\w\-]+)/([^\/]+)/(blob|tree)/(.*)$',
+        (r'^' + HTML_URL + r'([\w\-]+)/([^\/]+)/(blob|tree)/(.*)$',
             u'/' + PROVIDER_URL_FRAG + u'/{0}/{1}/{2}/{3}'),
         (r'^([\w\-]+)/([^\/]+)$',
             u'/' + PROVIDER_URL_FRAG + u'/{0}/{1}/tree/master/'),

--- a/nbviewer/providers/github/client.py
+++ b/nbviewer/providers/github/client.py
@@ -24,23 +24,23 @@ class AsyncGitHubClient(object):
     """AsyncHTTPClient wrapper with methods for common requests"""
 
     # Environment variables for Github auth
-    API_URL_ENV = ('GITHUB_API_URL', 'https://api.github.com/')
-    OAUTH_KEY_ENV = ('GITHUB_OAUTH_KEY', '')
-    OAUTH_SECRET_ENV = ('GITHUB_OAUTH_SECRET', '')
-    OAUTH_TOKEN_ENV = ('GITHUB_API_TOKEN', '')
+    ENV_PREFIX = 'GITHUB_'
 
     auth = None
 
     def __init__(self, client=None):
         self.client = client or AsyncHTTPClient()
-        self.github_api_url = os.environ.get(*self.API_URL_ENV)
+        self.github_api_url = self.env('API_URL', 'https://api.github.com/')
         self.authenticate()
+
+    def env(self, key, *args):
+        return os.environ.get(self.ENV_PREFIX + key, *args)
 
     def authenticate(self):
         self.auth = {
-            'client_id': os.environ.get(*self.OAUTH_KEY_ENV),
-            'client_secret': os.environ.get(*self.OAUTH_SECRET_ENV),
-            'access_token': os.environ.get(*self.OAUTH_TOKEN_ENV),
+            'client_id': self.env('OAUTH_KEY', ''),
+            'client_secret': self.env('OAUTH_SECRET', ''),
+            'access_token': self.env('OAUTH_TOKEN', ''),
         }
         self.auth = {k: v for k, v in self.auth.items() if v}
 

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -98,7 +98,7 @@ class GitHubUserHandler(GithubClientMixin, BaseHandler):
                 url=repo['name'],
                 name=repo['name'],
             ))
-        provider_url = u"{url}{user}".format(
+        provider_url = u"{url}/{user}".format(
             url=self.github_client.github_html_url,
             user=user
         )
@@ -163,7 +163,7 @@ class GitHubTreeHandler(GithubClientMixin, BaseHandler):
         base_url = u"/{provider}/{user}/{repo}/tree/{ref}".format(
             user=user, repo=repo, ref=ref, provider=self.PROVIDER_URL_FRAG,
         )
-        provider_url = u"{url}{user}/{repo}/tree/{ref}/{path}".format(
+        provider_url = u"{url}/{user}/{repo}/tree/{ref}/{path}".format(
             user=user, repo=repo, ref=ref, path=path,
             url=self.github_client.github_html_url,
         )


### PR DESCRIPTION
Based on #455, this adds Github Enterprise (`ghe`) as a provider... it's use case is different enough from public github, and it serves as a pattern for other public:tm:/hosted:copyleft: solutions:
- bitbucket/stash
- sourceforge/allura
- gitlab/gitlab

Here is an example of what it would look like to run `ghe`, and no other providers:

```bash
GITHUB_API_URL=https://api.my.internal.gh.enterprisey.com/ \
    GITHUB_HTML_URL=https://my.internal.gh.enterprisey.com/ \
    GITHUB_API_TOKEN=<whatever> \
    python -m nbviewer \
        --providers=nbviewer.providers.ghe \
        --provider-rewrites=nbviewer.providers.ghe
```

At present, it won't really be possible to use `ghe` and `github`, as they share the same keyspace... please chime in if this is an important feature It will just necessitate some more hacks.... however, if running an internal nbviewer, I would likely not have `github` (and maybe even `url`) enabled.

Adding appropriate tests will be challenging, and should likely begin the investigation of #423, and mocking up "real" github (refreshably scraped) for faster tests.

@mrterry I'm still working on this! had to knock off for a while!