### PR TITLE
enable mathjax equation numbering by default

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -87,6 +87,7 @@ def main():
     define("proxy_port", default="", help="The proxy port.", type=int)
     define("providers", default=default_providers, help="Full dotted package(s) that provide `default_handlers`", type=str, multiple=True, group="provider")
     define("provider_rewrites", default=default_rewrites, help="Full dotted package(s) that provide `uri_rewrites`", type=str, multiple=True, group="provider")
+    define("mathjax_url", default="https://cdn.mathjax.org/mathjax/latest/", help="URL base for mathjax package", type=str)
     tornado.options.parse_command_line()
 
     # NBConvert config
@@ -214,6 +215,7 @@ def main():
         render_timeout=20,
         localfile_path=os.path.abspath(options.localfiles),
         fetch_kwargs=fetch_kwargs,
+        mathjax_url=options.mathjax_url,
     )
 
     # handle handlers

--- a/nbviewer/formats.py
+++ b/nbviewer/formats.py
@@ -9,6 +9,7 @@ import re
 
 from IPython.nbconvert.exporters.export import exporter_map
 
+
 def default_formats():
     """
     Return the currently-implemented formats.

--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -116,6 +116,10 @@ class BaseHandler(web.RequestHandler):
     def frontpage_sections(self):
         return self.settings.setdefault('frontpage_sections', {})
 
+    @property
+    def mathjax_url(self):
+        return self.settings['mathjax_url']
+
     #---------------------------------------------------------------
     # template rendering
     #---------------------------------------------------------------
@@ -131,7 +135,9 @@ class BaseHandler(web.RequestHandler):
 
     @property
     def template_namespace(self):
-        return {}
+        return {
+            "mathjax_url": self.mathjax_url
+        }
 
     def breadcrumbs(self, path, base_url):
         """Generate a list of breadcrumbs"""

--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -55,6 +55,7 @@
       if (window.MathJax) {
         // MathJax loaded
         MathJax.Hub.Config({
+          TeX: { equationNumbers: { autoNumber: "AMS", useLabelIds: true } },
           tex2jax: {
             inlineMath: [ ['$','$'], ["\\(","\\)"] ],
             displayMath: [ ['$$','$$'], ["\\[","\\]"] ],

--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -48,31 +48,38 @@
     <link href="/static/css/theme/{{css_theme}}.css" rel="stylesheet">
   {% endif %}
 
-  <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" type="text/javascript">
-  </script>
-  <script type="text/javascript">
-    init_mathjax = function() {
-      if (window.MathJax) {
-        // MathJax loaded
-        MathJax.Hub.Config({
-          TeX: { equationNumbers: { autoNumber: "AMS", useLabelIds: true } },
-          tex2jax: {
-            inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-            displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-            processEscapes: true,
-            processEnvironments: true
-          },
-          displayAlign: 'center',
-          "HTML-CSS": {
-            styles: {'.MathJax_Display': {"margin": 0}},
-            linebreaks: { automatic: true }
-          }
-        });
-        MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+  {% block mathjax %}
+    <script src="{{ mathjax_url }}MathJax.js?config=TeX-AMS_HTML" type="text/javascript">
+    </script>
+    <script type="text/javascript">
+      init_mathjax = function() {
+        if (window.MathJax) {
+          // MathJax loaded
+          MathJax.Hub.Config({
+            TeX: {
+              equationNumbers: {
+                autoNumber: "AMS",
+                useLabelIds: true
+              }
+            },
+            tex2jax: {
+              inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+              displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+              processEscapes: true,
+              processEnvironments: true
+            },
+            displayAlign: 'center',
+            "HTML-CSS": {
+              styles: {'.MathJax_Display': {"margin": 0}},
+              linebreaks: { automatic: true }
+            }
+          });
+          MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+        }
       }
-    }
-    init_mathjax();
-  </script>
+      init_mathjax();
+    </script>
+  {% endblock mathjax %}
 {% endblock extra_head %}
 
 


### PR DESCRIPTION
It would be great if the nbviewer could handle numbered mathjax equations.

Check http://stackoverflow.com/questions/18823779/ipython-notebook-and-mathjax-labeled-equations
for more details