### PR TITLE
Minor reorg for easier testing

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 coverage
 invoke
-mock
+mock>=1.3.0
 nose
 requests
 -e .

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 coverage
 invoke
-mock>=1.3.0
+mock>=1.3.0  # python34 and older versions of mock do not play well together.
 nose
 requests
 -e .

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 coverage
 invoke
+mock
 nose
 requests
 -e .

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -308,25 +308,22 @@ def default_handlers(handlers=[]):
 
 def uri_rewrites(rewrites=[]):
     return rewrites + [
-        (r'^https?://github\.com/([^\/]+)/([^\/]+)/tree/([^\/]+)/(.*)',
-            '/github/{0}/{1}/tree/{3}/{4}'),
-        (r'^https?://github\.com/([^\/]+)/([^\/]+)/tree/([^\/]+)/(.*)',
-            '/github/{0}/{1}/blob/{3}/{4}'),
-
         # three different uris for a raw view
         (r'^https?://github\.com/([^\/]+)/([^\/]+)/raw/([^\/]+)/(.*)',
-            '/github/{0}/{1}/blob/{2}/{3}'),
+            u'/github/{0}/{1}/blob/{2}/{3}'),
         (r'^https?://raw\.github\.com/([^\/]+)/([^\/]+)/(.*)',
             u'/github/{0}/{1}/blob/{2}'),
         (r'^https?://raw\.githubusercontent\.com/([^\/]+)/([^\/]+)/(.*)',
             u'/github/{0}/{1}/blob/{2}'),
 
+        # trees & blobs
         (r'^https?://github.com/([\w\-]+)/([^\/]+)/(blob|tree)/(.*)$',
             u'/github/{0}/{1}/{2}/{3}'),
-        (r'^https?://raw.?github.com/([\w\-]+)/([^\/]+)/(.*)$',
-            u'/github/{0}/{1}/blob/{2}'),
+
+        # user/repo
         (r'^([\w\-]+)/([^\/]+)$',
             u'/github/{0}/{1}/tree/master/'),
+        # user
         (r'^([\w\-]+)$',
             u'/github/{0}/'),
     ]

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -294,6 +294,14 @@ def default_handlers(handlers=[]):
     """Tornado handlers"""
 
     return [
+        # ideally these URIs should have been caught by an appropriate
+        # uri_rewrite rather than letting the url provider catch them and then
+        # fixing it here.
+        # There are probably links in the wild that depend on these, so keep
+        # these handlers for backwards compatibility.
+        (r'/url[s]?/github\.com/([^\/]+)/([^\/]+)/(tree|blob|raw)/([^\/]+)/(.*)', GitHubRedirectHandler),
+        (r'/url[s]?/raw\.?github\.com/([^\/]+)/([^\/]+)/(.*)', RawGitHubURLHandler),
+        (r'/url[s]?/raw\.?githubusercontent\.com/([^\/]+)/([^\/]+)/(.*)', RawGitHubURLHandler),
     ] + handlers + [
         (r'/github/([^\/]+)', AddSlashHandler),
         (r'/github/([^\/]+)/', GitHubUserHandler),

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -294,8 +294,6 @@ def default_handlers(handlers=[]):
     """Tornado handlers"""
 
     return [
-        (r'/url[s]?/github\.com/([^\/]+)/([^\/]+)/(tree|blob|raw)/([^\/]+)/(.*)', GitHubRedirectHandler),
-        (r'/url[s]?/raw\.?github(?:usercontent)?\.com/([^\/]+)/([^\/]+)/(.*)', RawGitHubURLHandler),
     ] + handlers + [
         (r'/github/([^\/]+)', AddSlashHandler),
         (r'/github/([^\/]+)/', GitHubUserHandler),
@@ -304,12 +302,25 @@ def default_handlers(handlers=[]):
         (r'/github/([^\/]+)/([^\/]+)/blob/([^\/]+)/(.*)/', RemoveSlashHandler),
         (r'/github/([^\/]+)/([^\/]+)/blob/([^\/]+)/(.*)', GitHubBlobHandler),
         (r'/github/([^\/]+)/([^\/]+)/tree/([^\/]+)', AddSlashHandler),
-        (r'/github/([^\/]+)/([^\/]+)/tree/([^\/]+)/(.*)', GitHubTreeHandler)
+        (r'/github/([^\/]+)/([^\/]+)/tree/([^\/]+)/(.*)', GitHubTreeHandler),
     ]
 
 
 def uri_rewrites(rewrites=[]):
     return rewrites + [
+        (r'^https?://github\.com/([^\/]+)/([^\/]+)/tree/([^\/]+)/(.*)',
+            '/github/{0}/{1}/tree/{3}/{4}'),
+        (r'^https?://github\.com/([^\/]+)/([^\/]+)/tree/([^\/]+)/(.*)',
+            '/github/{0}/{1}/blob/{3}/{4}'),
+
+        # three different uris for a raw view
+        (r'^https?://github\.com/([^\/]+)/([^\/]+)/raw/([^\/]+)/(.*)',
+            '/github/{0}/{1}/blob/{2}/{3}'),
+        (r'^https?://raw\.github\.com/([^\/]+)/([^\/]+)/(.*)',
+            u'/github/{0}/{1}/blob/{2}'),
+        (r'^https?://raw\.githubusercontent\.com/([^\/]+)/([^\/]+)/(.*)',
+            u'/github/{0}/{1}/blob/{2}'),
+
         (r'^https?://github.com/([\w\-]+)/([^\/]+)/(blob|tree)/(.*)$',
             u'/github/{0}/{1}/{2}/{3}'),
         (r'^https?://raw.?github.com/([\w\-]+)/([^\/]+)/(.*)$',

--- a/nbviewer/providers/github/handlers_test.py
+++ b/nbviewer/providers/github/handlers_test.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+
+from ...utils import transform_ipynb_uri
+from .handlers import uri_rewrites
+
+class TestRewrite(TestCase):
+    def test_raw1(self):
+        uri = 'https://raw.githubusercontent.com/ipython/ipython/3.x/examples/Index.ipynb'
+        rewrite = u'/github/ipython/ipython/blob/3.x/examples/Index.ipynb'
+        new = transform_ipynb_uri(uri, rewrite_providers=['nbviewer.providers.github'])
+        self.assertEqual(new, rewrite)
+
+    def test_raw2(self):
+        uri = 'https://github.com/ipython/ipython/blob/3.x/examples/Index.ipynb'
+        rewrite = u'/github/ipython/ipython/blob/3.x/examples/Index.ipynb'
+        new = transform_ipynb_uri(uri, rewrite_providers=['nbviewer.providers.github'])
+        self.assertEqual(new, rewrite)
+
+    def test_raw3(self):
+        uri = 'https://github.com/ipython/ipython/raw/3.x/examples/Index.ipynb'
+        rewrite = u'/github/ipython/ipython/blob/3.x/examples/Index.ipynb'
+        new = transform_ipynb_uri(uri, rewrite_providers=['nbviewer.providers.github'])
+        self.assertEqual(new, rewrite)
+
+    def test_raw4(self):
+        uri = 'https://raw.github.com/ipython/ipython/3.x/examples/Index.ipynb'
+        rewrite = u'/github/ipython/ipython/blob/3.x/examples/Index.ipynb'
+        new = transform_ipynb_uri(uri, rewrite_providers=['nbviewer.providers.github'])
+        self.assertEqual(new, rewrite)
+

--- a/nbviewer/providers/github/handlers_test.py
+++ b/nbviewer/providers/github/handlers_test.py
@@ -1,30 +1,51 @@
-from unittest import TestCase
+# encoding: utf-8
 
-from ...utils import transform_ipynb_uri
+from unittest import TestCase
+from collections import OrderedDict
+
+from ...utils import _transform_ipynb_uri
 from .handlers import uri_rewrites
 
+uri_rewrite_dict = OrderedDict()
+uri_rewrite_dict.update(uri_rewrites())
+
+
 class TestRewrite(TestCase):
-    def test_raw1(self):
-        uri = 'https://raw.githubusercontent.com/ipython/ipython/3.x/examples/Index.ipynb'
-        rewrite = u'/github/ipython/ipython/blob/3.x/examples/Index.ipynb'
-        new = transform_ipynb_uri(uri, rewrite_providers=['nbviewer.providers.github'])
+    def assert_rewrite(self, uri, rewrite):
+        new = _transform_ipynb_uri(uri, uri_rewrite_dict)
         self.assertEqual(new, rewrite)
 
-    def test_raw2(self):
-        uri = 'https://github.com/ipython/ipython/blob/3.x/examples/Index.ipynb'
-        rewrite = u'/github/ipython/ipython/blob/3.x/examples/Index.ipynb'
-        new = transform_ipynb_uri(uri, rewrite_providers=['nbviewer.providers.github'])
-        self.assertEqual(new, rewrite)
+    def test_githubusercontent(self):
+        uri = u'https://raw.githubusercontent.com/user/reopname/deadbeef/a mřížka.ipynb'
+        rewrite = u'/github/user/reopname/blob/deadbeef/a mřížka.ipynb'
+        self.assert_rewrite(uri, rewrite)
 
-    def test_raw3(self):
-        uri = 'https://github.com/ipython/ipython/raw/3.x/examples/Index.ipynb'
-        rewrite = u'/github/ipython/ipython/blob/3.x/examples/Index.ipynb'
-        new = transform_ipynb_uri(uri, rewrite_providers=['nbviewer.providers.github'])
-        self.assertEqual(new, rewrite)
+    def test_blob(self):
+        uri = u'https://github.com/user/reopname/blob/deadbeef/a mřížka.ipynb'
+        rewrite = u'/github/user/reopname/blob/deadbeef/a mřížka.ipynb'
+        self.assert_rewrite(uri, rewrite)
 
-    def test_raw4(self):
-        uri = 'https://raw.github.com/ipython/ipython/3.x/examples/Index.ipynb'
-        rewrite = u'/github/ipython/ipython/blob/3.x/examples/Index.ipynb'
-        new = transform_ipynb_uri(uri, rewrite_providers=['nbviewer.providers.github'])
-        self.assertEqual(new, rewrite)
+    def test_raw_uri(self):
+        uri = u'https://github.com/user/reopname/raw/deadbeef/a mřížka.ipynb'
+        rewrite = u'/github/user/reopname/blob/deadbeef/a mřížka.ipynb'
+        self.assert_rewrite(uri, rewrite)
 
+    def test_raw_subdomain(self):
+        uri = u'https://raw.github.com/user/reopname/deadbeef/a mřížka.ipynb'
+        rewrite = u'/github/user/reopname/blob/deadbeef/a mřížka.ipynb'
+        self.assert_rewrite(uri, rewrite)
+
+    def test_tree(self):
+        uri = u'https://github.com/user/reopname/tree/deadbeef/a mřížka.ipynb'
+        rewrite = u'/github/user/reopname/tree/deadbeef/a mřížka.ipynb'
+        self.assert_rewrite(uri, rewrite)
+
+    def test_userrepo(self):
+        uri = u'username/reponame'
+        rewrite = u'/github/username/reponame/tree/master/'
+        self.assert_rewrite(uri, rewrite)
+
+    def test_user(self):
+        uri = u'username'
+        rewrite = u'/github/username/'
+        self.assert_rewrite(uri, rewrite)

--- a/nbviewer/providers/github/tests/test_client.py
+++ b/nbviewer/providers/github/tests/test_client.py
@@ -33,8 +33,6 @@ class GithubClientTest(AsyncTestCase):
         """
         if string.startswith(beginning):
             return
-        print beginning
-        print string
         self.assertTrue(string.startswith(beginning),
                         '%s does not start with %s' % (string, beginning))
 

--- a/nbviewer/providers/github/tests/test_client.py
+++ b/nbviewer/providers/github/tests/test_client.py
@@ -1,0 +1,107 @@
+# encoding: utf-8
+
+import mock
+
+from tornado.httpclient import AsyncHTTPClient
+from tornado.testing import AsyncTestCase
+
+from ..client import AsyncGitHubClient
+from ....utils import quote
+
+
+class GithubClientTest(AsyncTestCase):
+    """Tests that the github API client makes the correct http requests."""
+    def setUp(self):
+        super(GithubClientTest, self).setUp()
+        # Need a mock HTTPClient for the github client to talk to.
+        self.http_client = mock.create_autospec(AsyncHTTPClient)
+        
+        # patch the enviornment so that we get a known url prefix.
+        with mock.patch('os.environ.get', return_value='https://api.github.com/'):
+            self.gh_client = AsyncGitHubClient(client=self.http_client)
+
+    def _get_url(self):
+        """Get the last url requested from the mock http client."""
+        args, kw = self.http_client.fetch.call_args
+        return args[0]
+
+    def assertStartsWith(self, string, beginning):
+        """Assert that a url has the correct beginning.
+        
+        Github API requests involve non-trivial query strings.  This is useful
+        when you want to compare URLs, but don't care about the querystring.
+        """
+        if string.startswith(beginning):
+            return
+        print beginning
+        print string
+        self.assertTrue(string.startswith(beginning),
+                        '%s does not start with %s' % (string, beginning))
+
+    def test_basic_fetch(self):
+        """Test the mock http client is hit"""
+        self.gh_client.fetch('https://api.github.com/url')
+        self.assertTrue(self.http_client.fetch.called)
+
+    def test_fetch_params(self):
+        """Test params are passed through."""
+        params = {'unique_param_name': 1}
+        self.gh_client.fetch('https://api.github.com/url', params=params)
+        url = self._get_url()
+        self.assertTrue('unique_param_name' in url)
+
+    def test_log_rate_limit(self):
+        pass
+
+    def test_get_repos(self):
+        self.gh_client.get_repos('username')
+        url = self._get_url()
+        self.assertStartsWith(url, 'https://api.github.com/users/username/repos')
+
+    def test_get_contents(self):
+        user = 'username'
+        repo = 'my_awesome_repo'
+        path = u'möre-path'
+        self.gh_client.get_contents(user, repo, path)
+        url = self._get_url()
+        correct_url = u'https://api.github.com' + quote(u'/repos/username/my_awesome_repo/contents/möre-path')
+        self.assertStartsWith(url, correct_url)
+
+    def test_get_branches(self):
+        user = 'username'
+        repo = 'my_awesome_repo'
+        self.gh_client.get_branches(user, repo)
+        url = self._get_url()
+        correct_url = 'https://api.github.com/repos/username/my_awesome_repo/branches'
+        self.assertStartsWith(url, correct_url)
+
+    def test_get_tags(self):
+        user = 'username'
+        repo = 'my_awesome_repo'
+        self.gh_client.get_tags(user, repo)
+        url = self._get_url()
+        correct_url = 'https://api.github.com/repos/username/my_awesome_repo/tags'
+        self.assertStartsWith(url, correct_url)
+
+    def test_get_tree_entry(self):
+        user = 'username'
+        repo = 'my_awesome_repo'
+        path = 'extra-path'
+        self.gh_client.get_tree_entry(user, repo, path)
+        url = self._get_url()
+        correct_url = 'https://api.github.com/repos/username/my_awesome_repo/git/trees/master'
+        self.assertStartsWith(url, correct_url)
+
+    def test_get_gist(self):
+        gist_id = 'ap90avn23iovv2ovn2309n'
+        self.gh_client.get_gist(gist_id)
+        url = self._get_url()
+        correct_url = 'https://api.github.com/gists/' + gist_id
+        self.assertStartsWith(url, correct_url)
+
+    def test_get_gists(self):
+        user = 'username'
+        self.gh_client.get_gists(user)
+        url = self._get_url()
+        correct_url = 'https://api.github.com/users/username/gists'
+        self.assertStartsWith(url, correct_url)

--- a/nbviewer/providers/github/tests/test_handlers.py
+++ b/nbviewer/providers/github/tests/test_handlers.py
@@ -3,8 +3,8 @@
 from unittest import TestCase
 from collections import OrderedDict
 
-from ...utils import _transform_ipynb_uri
-from .handlers import uri_rewrites
+from ....utils import _transform_ipynb_uri
+from ..handlers import uri_rewrites
 
 uri_rewrite_dict = OrderedDict()
 uri_rewrite_dict.update(uri_rewrites())

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -67,7 +67,7 @@ uri_rewrite_dict = OrderedDict()
 def transform_ipynb_uri(value, rewrite_providers=None):
     """Transform a given value (an ipynb 'URI') into an app URL"""
 
-    if not uri_rewrite_dict:
+    if not uri_rewrite_dict or rewrite_providers:
         from .providers import (
             default_rewrites,
             provider_uri_rewrites,


### PR DESCRIPTION
Minor reorg to make unit testing providers easier.  Will get to #423 in time.

Makes uri translation function more accessible for tests and adds first pass for a github client that mocks out network communication.