### PR TITLE
Template security

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -155,7 +155,10 @@ def main():
 
     template_path = pjoin(here, 'templates')
     static_path = pjoin(here, 'static')
-    env = Environment(loader=FileSystemLoader(template_path))
+    env = Environment(
+        loader=FileSystemLoader(template_path),
+        autoescape=True
+    )
     env.filters['markdown'] = markdown.markdown
     try:
         git_data = git_info(here)
@@ -186,7 +189,7 @@ def main():
             max_cache_uris.add('/' + link['target'])
 
     fetch_kwargs = dict(connect_timeout=10,)
-    if options.proxy_host: 
+    if options.proxy_host:
         fetch_kwargs.update(dict(proxy_host=options.proxy_host,
                                  proxy_port=options.proxy_port))
 

--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -28,12 +28,21 @@ class LocalFileHandler(RenderingHandler):
     @cached
     @gen.coroutine
     def get(self, path):
-        abspath = os.path.join(
-            self.settings.get('localfile_path', ''),
-            path,
-        )
+
+        localfile_path = os.path.abspath(
+            self.settings.get('localfile_path', ''))
+
+        abspath = os.path.abspath(os.path.join(
+            localfile_path,
+            path
+        ))
 
         app_log.info("looking for file: '%s'" % abspath)
+
+        if not abspath.startswith(localfile_path):
+            app_log.info("directory traversl: '%s'" % localfile_path)
+            raise web.HTTPError(404)
+
         if not os.path.exists(abspath):
             raise web.HTTPError(404)
 

--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -40,7 +40,7 @@ class LocalFileHandler(RenderingHandler):
         app_log.info("looking for file: '%s'" % abspath)
 
         if not abspath.startswith(localfile_path):
-            app_log.info("directory traversl: '%s'" % localfile_path)
+            app_log.warn("directory traversal attempt: '%s'" % localfile_path)
             raise web.HTTPError(404)
 
         if not os.path.exists(abspath):

--- a/nbviewer/tests/test_security.py
+++ b/nbviewer/tests/test_security.py
@@ -1,0 +1,37 @@
+# coding: utf-8
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2015 The Jupyter Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+import requests
+
+from .base import NBViewerTestCase
+
+from ..providers.local.tests.test_localfile import (
+    LocalFileDefaultTestCase as LFDTC
+)
+
+class XSSTestCase(NBViewerTestCase):
+    def _xss(self, path, pattern='<script>alert'):
+        r = requests.get(self.url() + path)
+        self.assertEqual(r.status_code, 200)
+        self.assertNotIn(pattern, r.content)
+
+    def test_github_dirnames(self):
+        self._xss(
+            '/github/bburky/xss/tree/%3Cscript%3Ealert(1)%3C%2fscript%3E/'
+        )
+
+    def test_gist_filenames(self):
+        self._xss('/gist/bburky/c020825874798a6544a7')
+
+
+class LocalDirectoryTraversalTestCase(LFDTC):
+    def test_url(self):
+        ## assumes being run from base of this repo
+        url = self.url('localfile/../../foo.txt')
+        r = requests.get(url)
+        self.assertEqual(r.status_code, 404)

--- a/nbviewer/tests/test_security.py
+++ b/nbviewer/tests/test_security.py
@@ -11,7 +11,7 @@ import requests
 from .base import NBViewerTestCase
 
 from ..providers.local.tests.test_localfile import (
-    LocalFileDefaultTestCase as LFDTC
+    LocalFileRelativePathTestCase as LFRPTC
 )
 
 class XSSTestCase(NBViewerTestCase):
@@ -29,9 +29,9 @@ class XSSTestCase(NBViewerTestCase):
         self._xss('/gist/bburky/c020825874798a6544a7')
 
 
-class LocalDirectoryTraversalTestCase(LFDTC):
+class LocalDirectoryTraversalTestCase(LFRPTC):
     def test_url(self):
         ## assumes being run from base of this repo
-        url = self.url('localfile/../../foo.txt')
+        url = self.url('localfile/../README.md')
         r = requests.get(url)
         self.assertEqual(r.status_code, 404)


### PR DESCRIPTION
This adds tests and fixes for #471, #472 and #473.

As per @Carreau's suggestion, now using `autoescape` on the jinja2.Environment.

The localfile handler also will only serve files found under its path.

if someone really wants to fight for being able to allow escaping the directory they specify, i propose we put it behind a big gnarly config flag, i.e. `--very-insecure-traversal`.

I looked into a few tools for broader XSS exploration, but i think we'll have a lot of false positives... also, don't know which of them i can trust.