### PR TITLE
Fixing URL double-encode, dropbox-specifics

### DIFF
--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -17,10 +17,10 @@ from datetime import datetime
 try:
     # py3
     from http.client import responses
-    from urllib.parse import urlparse
+    from urllib.parse import urlparse, urlunparse
 except ImportError:
     from httplib import responses
-    from urlparse import urlparse
+    from urlparse import urlparse, urlunparse
 
 from tornado import (
     gen,
@@ -66,8 +66,22 @@ class BaseHandler(web.RequestHandler):
 
     # Overloaded methods
     def redirect(self, url, *args, **kwargs):
+        purl = urlparse(url)
+
+        eurl = urlunparse((
+            purl.scheme,
+            purl.netloc,
+            "/".join([
+                url_escape(url_unescape(p), plus=False)
+                for p in purl.path.split("/")
+            ]),
+            purl.params,
+            purl.query,
+            purl.fragment
+        ))
+
         return super(BaseHandler, self).redirect(
-            "/".join(map(url_escape, url.split("/"))),
+            eurl,
             *args,
             **kwargs
         )

--- a/nbviewer/providers/dropbox/handlers.py
+++ b/nbviewer/providers/dropbox/handlers.py
@@ -7,6 +7,6 @@
 
 def uri_rewrites(rewrites=[]):
     return rewrites + [
-        (r'^http(s?)://www.dropbox.com/(sh?)/(.+)$',
+        (r'^http(s?)://www.dropbox.com/(sh?)/(.+?)(\?dl=.)*$',
             u'/url{0}/dl.dropbox.com/{1}/{2}'),
     ]

--- a/nbviewer/providers/url/handlers.py
+++ b/nbviewer/providers/url/handlers.py
@@ -19,6 +19,7 @@ from tornado import (
     web,
 )
 from tornado.log import app_log
+from tornado.escape import url_unescape
 
 from ...utils import (
     quote,
@@ -35,15 +36,17 @@ class URLHandler(RenderingHandler):
     """Renderer for /url or /urls"""
     @cached
     @gen.coroutine
-    def get(self, secure, url):
+    def get(self, secure, netloc, url):
         proto = 'http' + secure
+        netloc = url_unescape(netloc)
 
         if '/?' in url:
             url, query = url.rsplit('/?', 1)
         else:
             query = None
 
-        remote_url = u"{}://{}".format(proto, quote(url))
+        remote_url = u"{}://{}/{}".format(proto, netloc, quote(url))
+
         if query:
             remote_url = remote_url + '?' + query
         if not url.endswith('.ipynb'):
@@ -95,7 +98,7 @@ def default_handlers(handlers=[]):
     """Tornado handlers"""
 
     return handlers + [
-        (r'/url([s]?)/(.*)', URLHandler),
+        (r'/url([s]?)/([^/]+)/(.*)', URLHandler),
     ]
 
 

--- a/nbviewer/tests/test_utils.py
+++ b/nbviewer/tests/test_utils.py
@@ -39,7 +39,7 @@ def test_transform_ipynb_uri():
           u'/url/dl.dropbox.com/s/bar/baz.qux'),
         ( u'https://www.dropbox.com/s/zip/baz.qux',
           u'/urls/dl.dropbox.com/s/zip/baz.qux'),
-        ( u'https://www.dropbox.com/sh/mhviow274da2wly/CZKwRRcA0k/nested/furthernested/User%2520Interface.ipynb',
+        ( u'https://www.dropbox.com/sh/mhviow274da2wly/CZKwRRcA0k/nested/furthernested/User%2520Interface.ipynb?dl=1',
           u'/urls/dl.dropbox.com/sh/mhviow274da2wly/CZKwRRcA0k/nested/furthernested/User%2520Interface.ipynb'),
         # URL
         ('https://example.org/ipynb',

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -75,15 +75,18 @@ def transform_ipynb_uri(value, rewrite_providers=None):
         rewrite_providers = rewrite_providers or default_rewrites
         uri_rewrite_dict.update(provider_uri_rewrites(rewrite_providers))
 
+    for reg, rewrite in uri_rewrite_dict.items():
+        matches = re.match(reg, value)
+        if matches:
+            value = rewrite.format(*matches.groups())
+            break
+
     # encode query parameters as last url part
     if '?' in value:
         value, query = value.split('?', 1)
         value = '%s/%s' % (value, quote('?' + query))
-    
-    for reg, rewrite in uri_rewrite_dict.items():
-        matches = re.match(reg, value)
-        if matches:
-            return rewrite.format(*matches.groups())
+
+    return value
 
 # get_encoding_from_headers from requests.utils (1.2.3)
 # (c) 2013 Kenneth Reitz


### PR DESCRIPTION
This adds some more robust redirect URL handling with `urlunparse`.

As it was the source of the problem reported in #480, specifically for dropbox, it also strips the `?dl=.` which the upstream doesn't care about anyway. To allow that, the `?` param handling now occurs _after_ `url_rewrites`.

While I was in there testing, I handled #379, I think, as it was messing up my local test stuff (since I don't have/want/trust dropbox).

Would love some other eyes on this, as we should get it out pretty soon!  