### PR TITLE
adding google drive rewrite provider

### DIFF
--- a/nbviewer/providers/__init__.py
+++ b/nbviewer/providers/__init__.py
@@ -9,7 +9,8 @@ default_providers = ['nbviewer.providers.{}'.format(prov)
                      for prov in ['url', 'github', 'gist']]
 
 default_rewrites = ['nbviewer.providers.{}'.format(prov)
-                    for prov in ['gist', 'github', 'dropbox', 'url']]
+                    for prov in ['gist', 'github', 'dropbox', 'googledrive',
+                                 'url']]
 
 
 def provider_handlers(providers=None):

--- a/nbviewer/providers/googledrive/__init__.py
+++ b/nbviewer/providers/googledrive/__init__.py
@@ -1,0 +1,1 @@
+from .handlers import uri_rewrites

--- a/nbviewer/providers/googledrive/handlers.py
+++ b/nbviewer/providers/googledrive/handlers.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2015 The Jupyter Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+def uri_rewrites(rewrites=[]):
+    return rewrites + [
+        (r'^http(s?)://drive\.google\.com/file/d/([^/]*).*$',
+            u'/url{0}/googledrive.com/host/{1}'),
+        (r'^http(s?)://drive\.google\.com/open\?id=([^&#]*).*$',
+            u'/url{0}/googledrive.com/host/{1}')
+    ]

--- a/nbviewer/tests/test_utils.py
+++ b/nbviewer/tests/test_utils.py
@@ -45,7 +45,7 @@ def test_transform_ipynb_uri():
         (u'http://drive.google.com/file/d/0B7d519FxJIqPYktaTVg1TTV1WDA/view?usp=sharing',
         '/url/googledrive.com/host/0B7d519FxJIqPYktaTVg1TTV1WDA'),
         (u'https://drive.google.com/open?id=0B7d519FxJIqPcEVOZXYzdGxBdzQ',
-        u'/url/googledrive.com/host/0B7d519FxJIqPYktaTVg1TTV1WDA'),
+        u'/urls/googledrive.com/host/0B7d519FxJIqPYktaTVg1TTV1WDA'),
         # URL
         ('https://example.org/ipynb',
         u'/urls/example.org/ipynb'),

--- a/nbviewer/tests/test_utils.py
+++ b/nbviewer/tests/test_utils.py
@@ -41,6 +41,11 @@ def test_transform_ipynb_uri():
           u'/urls/dl.dropbox.com/s/zip/baz.qux'),
         ( u'https://www.dropbox.com/sh/mhviow274da2wly/CZKwRRcA0k/nested/furthernested/User%2520Interface.ipynb?dl=1',
           u'/urls/dl.dropbox.com/sh/mhviow274da2wly/CZKwRRcA0k/nested/furthernested/User%2520Interface.ipynb'),
+        # Google Drive URLS
+        (u'http://drive.google.com/file/d/0B7d519FxJIqPYktaTVg1TTV1WDA/view?usp=sharing',
+        '/url/googledrive.com/host/0B7d519FxJIqPYktaTVg1TTV1WDA'),
+        (u'https://drive.google.com/open?id=0B7d519FxJIqPcEVOZXYzdGxBdzQ',
+        u'/url/googledrive.com/host/0B7d519FxJIqPYktaTVg1TTV1WDA'),
         # URL
         ('https://example.org/ipynb',
         u'/urls/example.org/ipynb'),


### PR DESCRIPTION
A dropbox-style provider based on #427.

Can take the two kinds of links i found in drive (the "share" UI and the "get link" UI).

Tests passing currently blocked by #481, as it uses `?` params.