### PR TITLE
Remove Mathjax render on fragments-related events.

### DIFF
--- a/nbviewer/templates/formats/slides.html
+++ b/nbviewer/templates/formats/slides.html
@@ -88,8 +88,7 @@
 
         // show/hide the nbviewer header on slide change
         Reveal.addEventListener('slidechanged', update);
-        Reveal.addEventListener('fragmentshown', update);
-        Reveal.addEventListener('fragmenthidden', update);
+
       }
     );//require
   </script>


### PR DESCRIPTION
This is related with https://github.com/jupyter/nbconvert/pull/81