### PR TITLE
Fixed imports of deprecated packages related to IPython.

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -23,7 +23,7 @@ from tornado.options import define, options
 
 from jinja2 import Environment, FileSystemLoader
 
-from IPython.config import Config
+from traitlets.config import Config
 
 from .handlers import init_handlers, format_handlers
 from .cache import DummyAsyncCache, AsyncMultipartMemcache, MockCache, pylibmc

--- a/nbviewer/formats.py
+++ b/nbviewer/formats.py
@@ -7,7 +7,7 @@
 
 import re
 
-from IPython.nbconvert.exporters.export import exporter_map
+from nbconvert.exporters.export import exporter_map
 
 
 def default_formats():

--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -8,7 +8,7 @@
 from tornado import web
 from tornado.log import app_log
 
-from IPython.html import DEFAULT_STATIC_FILES_PATH as ipython_static_path
+from notebook import DEFAULT_STATIC_FILES_PATH as ipython_static_path
 
 from .utils import transform_ipynb_uri
 

--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -35,7 +35,7 @@ from tornado.escape import (
 from tornado.ioloop import IOLoop
 from tornado.log import app_log
 
-from IPython.nbformat import (
+from nbformat import (
     current_nbformat,
     reads,
 )

--- a/nbviewer/render.py
+++ b/nbviewer/render.py
@@ -8,7 +8,7 @@
 import re
 
 from tornado.log import app_log
-from IPython.nbconvert.exporters import Exporter
+from nbconvert.exporters import Exporter
 
 #-----------------------------------------------------------------------------
 #

--- a/tasks.py
+++ b/tasks.py
@@ -8,7 +8,7 @@ import tempfile
 
 import invoke
 
-from IPython.html import DEFAULT_STATIC_FILES_PATH
+from notebook import DEFAULT_STATIC_FILES_PATH
 
 
 APP_ROOT = os.path.dirname(__file__)


### PR DESCRIPTION
Running the current nbviewer gives you several warnings about importing packages that have been deprecated. It seems to be related to the move of the IPython notebook into Jupyter.

These were the messages I got:
/home/aris/nbviewer/nb/local/lib/python2.7/site-packages/IPython/config.py:13: ShimWarning: The `IPython.config` package has been deprecated. You should import from traitlets.config instead.
  "You should import from traitlets.config instead.", ShimWarning)

/home/aris/nbviewer/nb/local/lib/python2.7/site-packages/IPython/html.py:14: ShimWarning: The `IPython.html` package has been deprecated. You should import from `notebook` instead. `IPython.html.widgets` has moved to `ipywidgets`.
  "`IPython.html.widgets` has moved to `ipywidgets`.", ShimWarning)

/home/aris/nbviewer/nb/local/lib/python2.7/site-packages/IPython/nbformat.py:13: ShimWarning: The `IPython.nbformat` package has been deprecated. You should import from nbformat instead.
  "You should import from nbformat instead.", ShimWarning)

/home/aris/nbviewer/nb/local/lib/python2.7/site-packages/IPython/nbconvert.py:13: ShimWarning: The `IPython.nbconvert` package has been deprecated. You should import from ipython_nbconvert instead.
  "You should import from ipython_nbconvert instead.", ShimWarning)

I fixed it by importing the updated package instead of the deprecated version. I also tested it after 
making the changes.
