### PR TITLE
Swap order of dev and requirements and dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Static assets are maintained with `bower` and `less` (which require having
 
 ```shell
 $ cd <path to repo>
-$ pip install -r dev-requirements.txt
+$ pip install -r requirements-dev.txt
 $ invoke bower
 $ invoke less [-d]
 ```
@@ -129,7 +129,7 @@ running:
 
 ```shell
 $ cd <path to repo>
-$ pip install -r dev-requirements.txt
+$ pip install -r requirements-dev.txt
 $ GITHUB_API_TOKEN=<your token> python setup.py test
 ```
 


### PR DESCRIPTION
This was probably a leftover from #493, now that the name has changed for the dev requirements file.

/cc @bollwyvl 