### PR TITLE
force utf-8 for notebook json requests

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -51,12 +51,14 @@ app_log = log.app_log
 here = os.path.dirname(__file__)
 pjoin = os.path.join
 
+
 def nrhead():
     try:
         import newrelic.agent
     except ImportError:
         return ''
     return newrelic.agent.get_browser_timing_header()
+
 
 def nrfoot():
     try:
@@ -68,28 +70,8 @@ def nrfoot():
 this_dir, this_filename = os.path.split(__file__)
 FRONTPAGE_JSON = os.path.join(this_dir, "frontpage.json")
 
-def make_app():
-    # command-line options
-    define("debug", default=False, help="run in debug mode", type=bool)
-    define("no_cache", default=False, help="Do not cache results", type=bool)
-    define("localfiles", default="", help="Allow to serve local files under /localfile/* this can be a security risk", type=str)
-    define("port", default=5000, help="run on the given port", type=int)
-    define("cache_expiry_min", default=10*60, help="minimum cache expiry (seconds)", type=int)
-    define("cache_expiry_max", default=2*60*60, help="maximum cache expiry (seconds)", type=int)
-    define("mc_threads", default=1, help="number of threads to use for Async Memcache", type=int)
-    define("threads", default=1, help="number of threads to use for rendering", type=int)
-    define("processes", default=0, help="use processes instead of threads for rendering", type=int)
-    define("frontpage", default=FRONTPAGE_JSON, help="path to json file containing frontpage content", type=str)
-    define("sslcert", help="path to ssl .crt file", type=str)
-    define("sslkey", help="path to ssl .key file", type=str)
-    define("default_format", default="html", help="format to use for legacy / URLs", type=str)
-    define("proxy_host", default="", help="The proxy URL.", type=str)
-    define("proxy_port", default="", help="The proxy port.", type=int)
-    define("providers", default=default_providers, help="Full dotted package(s) that provide `default_handlers`", type=str, multiple=True, group="provider")
-    define("provider_rewrites", default=default_rewrites, help="Full dotted package(s) that provide `uri_rewrites`", type=str, multiple=True, group="provider")
-    define("mathjax_url", default="https://cdn.mathjax.org/mathjax/latest/", help="URL base for mathjax package", type=str)
-    tornado.options.parse_command_line()
 
+def make_app():
     # NBConvert config
     config = Config()
     config.NbconvertApp.fileext = 'html'
@@ -238,7 +220,32 @@ def make_app():
     return web.Application(handlers, debug=options.debug, **settings)
 
 
+def init_options():
+    # command-line options
+    define("debug", default=False, help="run in debug mode", type=bool)
+    define("no_cache", default=False, help="Do not cache results", type=bool)
+    define("localfiles", default="", help="Allow to serve local files under /localfile/* this can be a security risk", type=str)
+    define("port", default=5000, help="run on the given port", type=int)
+    define("cache_expiry_min", default=10*60, help="minimum cache expiry (seconds)", type=int)
+    define("cache_expiry_max", default=2*60*60, help="maximum cache expiry (seconds)", type=int)
+    define("mc_threads", default=1, help="number of threads to use for Async Memcache", type=int)
+    define("threads", default=1, help="number of threads to use for rendering", type=int)
+    define("processes", default=0, help="use processes instead of threads for rendering", type=int)
+    define("frontpage", default=FRONTPAGE_JSON, help="path to json file containing frontpage content", type=str)
+    define("sslcert", help="path to ssl .crt file", type=str)
+    define("sslkey", help="path to ssl .key file", type=str)
+    define("default_format", default="html", help="format to use for legacy / URLs", type=str)
+    define("proxy_host", default="", help="The proxy URL.", type=str)
+    define("proxy_port", default="", help="The proxy port.", type=int)
+    define("providers", default=default_providers, help="Full dotted package(s) that provide `default_handlers`", type=str, multiple=True, group="provider")
+    define("provider_rewrites", default=default_rewrites, help="Full dotted package(s) that provide `uri_rewrites`", type=str, multiple=True, group="provider")
+    define("mathjax_url", default="https://cdn.mathjax.org/mathjax/latest/", help="URL base for mathjax package", type=str)
+
+
 def main():
+    init_options()
+    tornado.options.parse_command_line()
+
     # create and start the app
     app = make_app()
 

--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -68,7 +68,7 @@ def nrfoot():
 this_dir, this_filename = os.path.split(__file__)
 FRONTPAGE_JSON = os.path.join(this_dir, "frontpage.json")
 
-def main():
+def make_app():
     # command-line options
     define("debug", default=False, help="run in debug mode", type=bool)
     define("no_cache", default=False, help="Do not cache results", type=bool)
@@ -234,6 +234,14 @@ def main():
             handlers
         )
 
+    # create the app
+    return web.Application(handlers, debug=options.debug, **settings)
+
+
+def main():
+    # create and start the app
+    app = make_app()
+
     # load ssl options
     ssl_options = None
     if options.sslcert:
@@ -242,8 +250,6 @@ def main():
             'keyfile' : options.sslkey,
         }
 
-    # create and start the app
-    app = web.Application(handlers, debug=options.debug, **settings)
     http_server = httpserver.HTTPServer(app, xheaders=True, ssl_options=ssl_options)
     log.app_log.info("Listening on port %i", options.port)
     http_server.listen(options.port)

--- a/nbviewer/providers/url/handlers.py
+++ b/nbviewer/providers/url/handlers.py
@@ -82,7 +82,7 @@ class URLHandler(RenderingHandler):
         response = yield self.fetch(remote_url)
 
         try:
-            nbjson = response_text(response)
+            nbjson = response_text(response, encoding='utf-8')
         except UnicodeDecodeError:
             app_log.error("Notebook is not utf8: %s", remote_url, exc_info=True)
             raise web.HTTPError(400)

--- a/nbviewer/providers/url/tests/test_content.py
+++ b/nbviewer/providers/url/tests/test_content.py
@@ -1,0 +1,12 @@
+from ....tests.async_base import AsyncNbviewerTestCase
+
+
+class ForceUTF8TestCase(AsyncNbviewerTestCase):
+    def test_utf8(self):
+        """ #507, bitbucket returns no content headers, but _is_ serving utf-8
+        """
+        response = self.fetch(
+            '/urls/bitbucket.org/sandiego206/asdasd/raw/master/Untitled.ipynb'
+        )
+        self.assertEqual(response.code, 200)
+        self.assertIn("ñ", response.body)

--- a/nbviewer/providers/url/tests/test_content.py
+++ b/nbviewer/providers/url/tests/test_content.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from ....tests.async_base import AsyncNbviewerTestCase
 
 

--- a/nbviewer/tests/async_base.py
+++ b/nbviewer/tests/async_base.py
@@ -1,0 +1,33 @@
+from tornado import testing
+from tornado.escape import to_unicode
+
+from ..app import make_app
+
+
+class AsyncNbviewerTestCase(testing.AsyncHTTPTestCase):
+    """ Base case for testing the nbviewer app asynchronously
+    """
+    def get_app(self):
+        """ create an nbviewer tornado app instance for testing
+        """
+        return make_app()
+
+    def assertIn(self, observed, expected, *args, **kwargs):
+        """ test whether the observed contains the expected, in utf-8
+        """
+        return super(AsyncNbviewerTestCase, self).assertIn(
+            to_unicode(observed),
+            to_unicode(expected),
+            *args,
+            **kwargs
+        )
+
+    def assertNotIn(self, observed, expected, *args, **kwargs):
+        """ test whether the observed does not contain the expected, in utf-8
+        """
+        return super(AsyncNbviewerTestCase, self).assertNotIn(
+            to_unicode(observed),
+            to_unicode(expected),
+            *args,
+            **kwargs
+        )

--- a/nbviewer/tests/async_base.py
+++ b/nbviewer/tests/async_base.py
@@ -1,7 +1,7 @@
 from tornado import testing
 from tornado.escape import to_unicode
 
-from ..app import make_app
+from .. import app
 
 
 class AsyncNbviewerTestCase(testing.AsyncHTTPTestCase):
@@ -10,7 +10,8 @@ class AsyncNbviewerTestCase(testing.AsyncHTTPTestCase):
     def get_app(self):
         """ create an nbviewer tornado app instance for testing
         """
-        return make_app()
+        app.init_options()
+        return app.make_app()
 
     def assertIn(self, observed, expected, *args, **kwargs):
         """ test whether the observed contains the expected, in utf-8

--- a/nbviewer/tests/base.py
+++ b/nbviewer/tests/base.py
@@ -27,22 +27,6 @@ class NBViewerTestCase(TestCase):
     """A base class for tests that need a running nbviewer server."""
 
     port = 12341
-    
-    def assertIn(self, observed, expected, *args, **kwargs):
-        return super(NBViewerTestCase, self).assertIn(
-            to_unicode(observed),
-            to_unicode(expected),
-            *args,
-            **kwargs
-        )
-
-    def assertNotIn(self, observed, expected, *args, **kwargs):
-        return super(NBViewerTestCase, self).assertNotIn(
-            to_unicode(observed),
-            to_unicode(expected),
-            *args,
-            **kwargs
-        )
 
     def assertIn(self, observed, expected, *args, **kwargs):
         return super(NBViewerTestCase, self).assertIn(

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -20,7 +20,7 @@ from IPython.utils import py3compat
 
 def quote(s):
     """unicode-safe quote
-    
+
     - Python 2 requires str, not unicode
     - always return unicode
     """
@@ -94,8 +94,12 @@ def get_encoding_from_headers(headers):
     if 'charset' in params:
         return params['charset'].strip("'\"")
 
+
+    # per #507, at least some hosts are providing UTF-8 without declaring it
+    # while the former choice of ISO-8859-1 wasn't known to be causing problems
+    # in the wild
     if 'text' in content_type:
-        return 'ISO-8859-1'
+        return 'utf-8'
 
 def response_text(response, encoding=None):
     """mimic requests.text property, but for plain HTTPResponse"""
@@ -137,7 +141,7 @@ def parse_header_links(value):
                 break
 
             link[key.strip(replace_chars)] = value.strip(replace_chars)
-        
+
         if 'rel' in link:
             links[link['rel']] = link
 
@@ -164,7 +168,7 @@ def ipython_info():
 
 def base64_decode(s):
     """unicode-safe base64
-    
+
     base64 API only talks bytes
     """
     s = py3compat.cast_bytes(s)
@@ -173,7 +177,7 @@ def base64_decode(s):
 
 def base64_encode(s):
     """unicode-safe base64
-    
+
     base64 API only talks bytes
     """
     s = py3compat.cast_bytes(s)


### PR DESCRIPTION
JSON (and therefore all ipynb) should be served as utf-8.

This proposes that the url provider always use `utf-8` to decode what is coming back.

The default of [`ISO-8859-1`](https://github.com/jupyter/nbviewer/blob/4df8cfd919c87e03c029638b0b060555cd340c51/nbviewer/utils.py#L98) when `text/*` is received could stand, but maybe even it should be `utf-8`?