### PR TITLE
slide templates

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -51,12 +51,14 @@ app_log = log.app_log
 here = os.path.dirname(__file__)
 pjoin = os.path.join
 
+
 def nrhead():
     try:
         import newrelic.agent
     except ImportError:
         return ''
     return newrelic.agent.get_browser_timing_header()
+
 
 def nrfoot():
     try:
@@ -68,28 +70,8 @@ def nrfoot():
 this_dir, this_filename = os.path.split(__file__)
 FRONTPAGE_JSON = os.path.join(this_dir, "frontpage.json")
 
-def make_app():
-    # command-line options
-    define("debug", default=False, help="run in debug mode", type=bool)
-    define("no_cache", default=False, help="Do not cache results", type=bool)
-    define("localfiles", default="", help="Allow to serve local files under /localfile/* this can be a security risk", type=str)
-    define("port", default=5000, help="run on the given port", type=int)
-    define("cache_expiry_min", default=10*60, help="minimum cache expiry (seconds)", type=int)
-    define("cache_expiry_max", default=2*60*60, help="maximum cache expiry (seconds)", type=int)
-    define("mc_threads", default=1, help="number of threads to use for Async Memcache", type=int)
-    define("threads", default=1, help="number of threads to use for rendering", type=int)
-    define("processes", default=0, help="use processes instead of threads for rendering", type=int)
-    define("frontpage", default=FRONTPAGE_JSON, help="path to json file containing frontpage content", type=str)
-    define("sslcert", help="path to ssl .crt file", type=str)
-    define("sslkey", help="path to ssl .key file", type=str)
-    define("default_format", default="html", help="format to use for legacy / URLs", type=str)
-    define("proxy_host", default="", help="The proxy URL.", type=str)
-    define("proxy_port", default="", help="The proxy port.", type=int)
-    define("providers", default=default_providers, help="Full dotted package(s) that provide `default_handlers`", type=str, multiple=True, group="provider")
-    define("provider_rewrites", default=default_rewrites, help="Full dotted package(s) that provide `uri_rewrites`", type=str, multiple=True, group="provider")
-    define("mathjax_url", default="https://cdn.mathjax.org/mathjax/latest/", help="URL base for mathjax package", type=str)
-    tornado.options.parse_command_line()
 
+def make_app():
     # NBConvert config
     config = Config()
     config.NbconvertApp.fileext = 'html'
@@ -238,7 +220,32 @@ def make_app():
     return web.Application(handlers, debug=options.debug, **settings)
 
 
+def init_options():
+    # command-line options
+    define("debug", default=False, help="run in debug mode", type=bool)
+    define("no_cache", default=False, help="Do not cache results", type=bool)
+    define("localfiles", default="", help="Allow to serve local files under /localfile/* this can be a security risk", type=str)
+    define("port", default=5000, help="run on the given port", type=int)
+    define("cache_expiry_min", default=10*60, help="minimum cache expiry (seconds)", type=int)
+    define("cache_expiry_max", default=2*60*60, help="maximum cache expiry (seconds)", type=int)
+    define("mc_threads", default=1, help="number of threads to use for Async Memcache", type=int)
+    define("threads", default=1, help="number of threads to use for rendering", type=int)
+    define("processes", default=0, help="use processes instead of threads for rendering", type=int)
+    define("frontpage", default=FRONTPAGE_JSON, help="path to json file containing frontpage content", type=str)
+    define("sslcert", help="path to ssl .crt file", type=str)
+    define("sslkey", help="path to ssl .key file", type=str)
+    define("default_format", default="html", help="format to use for legacy / URLs", type=str)
+    define("proxy_host", default="", help="The proxy URL.", type=str)
+    define("proxy_port", default="", help="The proxy port.", type=int)
+    define("providers", default=default_providers, help="Full dotted package(s) that provide `default_handlers`", type=str, multiple=True, group="provider")
+    define("provider_rewrites", default=default_rewrites, help="Full dotted package(s) that provide `uri_rewrites`", type=str, multiple=True, group="provider")
+    define("mathjax_url", default="https://cdn.mathjax.org/mathjax/latest/", help="URL base for mathjax package", type=str)
+
+
 def main():
+    init_options()
+    tornado.options.parse_command_line()
+
     # create and start the app
     app = make_app()
 

--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -68,7 +68,7 @@ def nrfoot():
 this_dir, this_filename = os.path.split(__file__)
 FRONTPAGE_JSON = os.path.join(this_dir, "frontpage.json")
 
-def main():
+def make_app():
     # command-line options
     define("debug", default=False, help="run in debug mode", type=bool)
     define("no_cache", default=False, help="Do not cache results", type=bool)
@@ -234,6 +234,14 @@ def main():
             handlers
         )
 
+    # create the app
+    return web.Application(handlers, debug=options.debug, **settings)
+
+
+def main():
+    # create and start the app
+    app = make_app()
+
     # load ssl options
     ssl_options = None
     if options.sslcert:
@@ -242,8 +250,6 @@ def main():
             'keyfile' : options.sslkey,
         }
 
-    # create and start the app
-    app = web.Application(handlers, debug=options.debug, **settings)
     http_server = httpserver.HTTPServer(app, xheaders=True, ssl_options=ssl_options)
     log.app_log.info("Listening on port %i", options.port)
     http_server.listen(options.port)

--- a/nbviewer/formats.py
+++ b/nbviewer/formats.py
@@ -57,6 +57,7 @@ def configure_formats(options, config, log, formats=None):
     # This would be better defined in a class
     config.HTMLExporter.template_file = 'basic'
     config.SlidesExporter.template_file = 'slides_reveal'
+
     config.TemplateExporter.template_path = [
         os.path.join(os.path.dirname(__file__), "templates", "nbconvert")
     ]

--- a/nbviewer/formats.py
+++ b/nbviewer/formats.py
@@ -6,6 +6,7 @@
 #-----------------------------------------------------------------------------
 
 import re
+import os
 
 from nbconvert.exporters.export import exporter_map
 
@@ -31,9 +32,6 @@ def default_formats():
         perform any modifications to html and resources after nbconvert
     """
 
-    reveal_body = re.compile(r'.*<body>(.*)<script[^>]+head.min.*',
-                             flags=re.MULTILINE | re.DOTALL)
-
     return {
         'html': {
             'nbconvert_template': 'basic',
@@ -45,11 +43,6 @@ def default_formats():
             'label': 'Slides',
             'icon': 'gift',
             'test': lambda nb, json: '"slideshow"' in json,
-            'postprocess': lambda html, resources: (
-                reveal_body.sub('\\1', html),
-                resources
-            ),
-
         }
     }
 
@@ -64,6 +57,9 @@ def configure_formats(options, config, log, formats=None):
     # This would be better defined in a class
     config.HTMLExporter.template_file = 'basic'
     config.SlidesExporter.template_file = 'slides_reveal'
+    config.TemplateExporter.template_path = [
+        os.path.join(os.path.dirname(__file__), "templates", "nbconvert")
+    ]
 
     for key, format in formats.items():
         exporter_cls = format.get("exporter", exporter_map[key])

--- a/nbviewer/providers/url/handlers.py
+++ b/nbviewer/providers/url/handlers.py
@@ -82,7 +82,7 @@ class URLHandler(RenderingHandler):
         response = yield self.fetch(remote_url)
 
         try:
-            nbjson = response_text(response)
+            nbjson = response_text(response, encoding='utf-8')
         except UnicodeDecodeError:
             app_log.error("Notebook is not utf8: %s", remote_url, exc_info=True)
             raise web.HTTPError(400)

--- a/nbviewer/providers/url/tests/test_content.py
+++ b/nbviewer/providers/url/tests/test_content.py
@@ -1,0 +1,12 @@
+from ....tests.async_base import AsyncNbviewerTestCase
+
+
+class ForceUTF8TestCase(AsyncNbviewerTestCase):
+    def test_utf8(self):
+        """ #507, bitbucket returns no content headers, but _is_ serving utf-8
+        """
+        response = self.fetch(
+            '/urls/bitbucket.org/sandiego206/asdasd/raw/master/Untitled.ipynb'
+        )
+        self.assertEqual(response.code, 200)
+        self.assertIn("ñ", response.body)

--- a/nbviewer/providers/url/tests/test_content.py
+++ b/nbviewer/providers/url/tests/test_content.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from ....tests.async_base import AsyncNbviewerTestCase
 
 

--- a/nbviewer/static/less/slides.less
+++ b/nbviewer/static/less/slides.less
@@ -9,7 +9,8 @@ body {
 }
 
 .reveal {
-  font-size: 160%;
+  font-size: 130%;
+  overflow-y: scroll;
 
   pre {
     width: inherit;
@@ -18,6 +19,10 @@ body {
     font-family: monospace, sans-serif;
     font-size: 80%;
     box-shadow: 0px 0px 0px rgba(0, 0, 0, 0);
+
+    code {
+      padding: 0px;
+    }
   }
 
   section img {
@@ -37,6 +42,11 @@ body {
 
   &.fade {
     opacity: 1;
+  }
+
+  .text_cell.rendered .rendered_html {
+    /* The H1 height seems miscalculated, we are just hidding the scrollbar */
+    overflow-y: hidden;
   }
 }
 

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -59,20 +59,20 @@
 
   <!-- Le fav and touch icons -->
   <link rel="shortcut icon" href="/static/ico/ipynb_icon_16x16.png">
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" 
+  <link rel="apple-touch-icon-precomposed" sizes="144x144"
         href="/static/ico/apple-touch-icon-144-precomposed.png">
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" 
+  <link rel="apple-touch-icon-precomposed" sizes="114x114"
         href="/static/ico/apple-touch-icon-114-precomposed.png">
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" 
+  <link rel="apple-touch-icon-precomposed" sizes="72x72"
         href="/static/ico/apple-touch-icon-72-precomposed.png">
-  <link rel="apple-touch-icon-precomposed" 
+  <link rel="apple-touch-icon-precomposed"
         href="/static/ico/apple-touch-icon-57-precomposed.png">
   {% block extra_head %}{% endblock %}
 </head>
 
 <body data-spy="scroll" data-target=".subnav" data-offset="50">
 
-  <!-- These are loaded at the top of the body so they are available to 
+  <!-- These are loaded at the top of the body so they are available to
        notebook cells when they are loaded below. -->
   <script src="/static/components/jquery/dist/jquery.min.js"></script>
   <script src="/static/components/requirejs/require.js"></script>
@@ -100,7 +100,7 @@
             <a href="http://jupyter.org">Jupyter</a>
           </li>
         </ul>
-        
+
         <ul class="nav navbar-nav navbar-right">
           {% block otherlinks %}
             {% if provider_url %}
@@ -136,7 +136,7 @@
 
         <div class="col-md-4">
           <p>
-            Delivered by <a href="http://www.fastly.com/">Fastly</a>, 
+            Delivered by <a href="http://www.fastly.com/">Fastly</a>,
             Rendered by <a href="https://developer.rackspace.com/?nbviewer=awesome">Rackspace</a>
           </p>
           <p>

--- a/nbviewer/templates/nbconvert/slides_reveal.tpl
+++ b/nbviewer/templates/nbconvert/slides_reveal.tpl
@@ -1,0 +1,41 @@
+{%- extends 'basic.tpl' -%}
+
+{%- block any_cell scoped -%}
+{%- if cell.metadata.get('slide_start', False) -%}
+<section>
+{%- endif -%}
+{%- if cell.metadata.get('subslide_start', False) -%}
+<section>
+{%- endif -%}
+{%- if cell.metadata.get('fragment_start', False) -%}
+<div class="fragment">
+{%- endif -%}
+
+{%- if cell.metadata.slide_type == 'notes' -%}
+<aside class="notes">
+{{ super() }}
+</aside>
+{%- elif cell.metadata.slide_type == 'skip' -%}
+{%- else -%}
+{{ super() }}
+{%- endif -%}
+
+{%- if cell.metadata.get('fragment_end', False) -%}
+</div>
+{%- endif -%}
+{%- if cell.metadata.get('subslide_end', False) -%}
+</section>
+{%- endif -%}
+{%- if cell.metadata.get('slide_end', False) -%}
+</section>
+{%- endif -%}
+
+{%- endblock any_cell -%}
+
+{% block body %}
+<div class="reveal">
+<div class="slides">
+{{ super() }}
+</div>
+</div>
+{% endblock body %}

--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -17,7 +17,7 @@
   {% if "kernelspec" in nb.metadata %}
     {{ layout.head_icon("#", nb.metadata.kernelspec.display_name + " Kernel", "server") }}
   {% endif %}
-  
+
   {% if provider_url %}
     {{ layout.head_icon(provider_url, "View on " + provider_label, provider_icon) }}
   {% endif %}

--- a/nbviewer/tests/async_base.py
+++ b/nbviewer/tests/async_base.py
@@ -1,0 +1,33 @@
+from tornado import testing
+from tornado.escape import to_unicode
+
+from ..app import make_app
+
+
+class AsyncNbviewerTestCase(testing.AsyncHTTPTestCase):
+    """ Base case for testing the nbviewer app asynchronously
+    """
+    def get_app(self):
+        """ create an nbviewer tornado app instance for testing
+        """
+        return make_app()
+
+    def assertIn(self, observed, expected, *args, **kwargs):
+        """ test whether the observed contains the expected, in utf-8
+        """
+        return super(AsyncNbviewerTestCase, self).assertIn(
+            to_unicode(observed),
+            to_unicode(expected),
+            *args,
+            **kwargs
+        )
+
+    def assertNotIn(self, observed, expected, *args, **kwargs):
+        """ test whether the observed does not contain the expected, in utf-8
+        """
+        return super(AsyncNbviewerTestCase, self).assertNotIn(
+            to_unicode(observed),
+            to_unicode(expected),
+            *args,
+            **kwargs
+        )

--- a/nbviewer/tests/async_base.py
+++ b/nbviewer/tests/async_base.py
@@ -1,7 +1,7 @@
 from tornado import testing
 from tornado.escape import to_unicode
 
-from ..app import make_app
+from .. import app
 
 
 class AsyncNbviewerTestCase(testing.AsyncHTTPTestCase):
@@ -10,7 +10,8 @@ class AsyncNbviewerTestCase(testing.AsyncHTTPTestCase):
     def get_app(self):
         """ create an nbviewer tornado app instance for testing
         """
-        return make_app()
+        app.init_options()
+        return app.make_app()
 
     def assertIn(self, observed, expected, *args, **kwargs):
         """ test whether the observed contains the expected, in utf-8

--- a/nbviewer/tests/base.py
+++ b/nbviewer/tests/base.py
@@ -27,22 +27,6 @@ class NBViewerTestCase(TestCase):
     """A base class for tests that need a running nbviewer server."""
 
     port = 12341
-    
-    def assertIn(self, observed, expected, *args, **kwargs):
-        return super(NBViewerTestCase, self).assertIn(
-            to_unicode(observed),
-            to_unicode(expected),
-            *args,
-            **kwargs
-        )
-
-    def assertNotIn(self, observed, expected, *args, **kwargs):
-        return super(NBViewerTestCase, self).assertNotIn(
-            to_unicode(observed),
-            to_unicode(expected),
-            *args,
-            **kwargs
-        )
 
     def assertIn(self, observed, expected, *args, **kwargs):
         return super(NBViewerTestCase, self).assertIn(

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -20,7 +20,7 @@ from IPython.utils import py3compat
 
 def quote(s):
     """unicode-safe quote
-    
+
     - Python 2 requires str, not unicode
     - always return unicode
     """
@@ -94,8 +94,12 @@ def get_encoding_from_headers(headers):
     if 'charset' in params:
         return params['charset'].strip("'\"")
 
+
+    # per #507, at least some hosts are providing UTF-8 without declaring it
+    # while the former choice of ISO-8859-1 wasn't known to be causing problems
+    # in the wild
     if 'text' in content_type:
-        return 'ISO-8859-1'
+        return 'utf-8'
 
 def response_text(response, encoding=None):
     """mimic requests.text property, but for plain HTTPResponse"""
@@ -137,7 +141,7 @@ def parse_header_links(value):
                 break
 
             link[key.strip(replace_chars)] = value.strip(replace_chars)
-        
+
         if 'rel' in link:
             links[link['rel']] = link
 
@@ -164,7 +168,7 @@ def ipython_info():
 
 def base64_decode(s):
     """unicode-safe base64
-    
+
     base64 API only talks bytes
     """
     s = py3compat.cast_bytes(s)
@@ -173,7 +177,7 @@ def base64_decode(s):
 
 def base64_encode(s):
     """unicode-safe base64
-    
+
     base64 API only talks bytes
     """
     s = py3compat.cast_bytes(s)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
+  "scripts": {
+    "watch-less": "./node_modules/.bin/watch 'invoke less' ./nbviewer/static/less"
+  },
   "devDependencies": {
     "less": "*",
     "less-plugin-autoprefix": "*",
     "less-plugin-clean-css": "*",
-    "bower": "*"
+    "bower": "*",
+    "watch": "*"
   }
 }


### PR DESCRIPTION
This fixes #506 and removes the awful body regex that breaks with bokeh, etc.

To do this, nbviewer now specifies its own template path for nbconvert, which can override or import the base ones. We have much more control over what we get from nbconvert this way, but are duplicating some effort: however, updating to `master` whenever nbconvert 4.next lands will be less of a big deal than it would have been otherwise for slides.

This is branched this off #508, but probably shouldn't have been. Whoops.

cc @damianavila 