### PR TITLE
Slide templates

### DIFF
--- a/nbviewer/formats.py
+++ b/nbviewer/formats.py
@@ -57,6 +57,7 @@ def configure_formats(options, config, log, formats=None):
     # This would be better defined in a class
     config.HTMLExporter.template_file = 'basic'
     config.SlidesExporter.template_file = 'slides_reveal'
+
     config.TemplateExporter.template_path = [
         os.path.join(os.path.dirname(__file__), "templates", "nbconvert")
     ]

--- a/nbviewer/formats.py
+++ b/nbviewer/formats.py
@@ -6,6 +6,7 @@
 #-----------------------------------------------------------------------------
 
 import re
+import os
 
 from nbconvert.exporters.export import exporter_map
 
@@ -31,9 +32,6 @@ def default_formats():
         perform any modifications to html and resources after nbconvert
     """
 
-    reveal_body = re.compile(r'.*<body>(.*)<script[^>]+head.min.*',
-                             flags=re.MULTILINE | re.DOTALL)
-
     return {
         'html': {
             'nbconvert_template': 'basic',
@@ -45,11 +43,6 @@ def default_formats():
             'label': 'Slides',
             'icon': 'gift',
             'test': lambda nb, json: '"slideshow"' in json,
-            'postprocess': lambda html, resources: (
-                reveal_body.sub('\\1', html),
-                resources
-            ),
-
         }
     }
 
@@ -64,6 +57,9 @@ def configure_formats(options, config, log, formats=None):
     # This would be better defined in a class
     config.HTMLExporter.template_file = 'basic'
     config.SlidesExporter.template_file = 'slides_reveal'
+    config.TemplateExporter.template_path = [
+        os.path.join(os.path.dirname(__file__), "templates", "nbconvert")
+    ]
 
     for key, format in formats.items():
         exporter_cls = format.get("exporter", exporter_map[key])

--- a/nbviewer/static/less/slides.less
+++ b/nbviewer/static/less/slides.less
@@ -9,7 +9,8 @@ body {
 }
 
 .reveal {
-  font-size: 160%;
+  font-size: 130%;
+  overflow-y: scroll;
 
   pre {
     width: inherit;
@@ -18,6 +19,10 @@ body {
     font-family: monospace, sans-serif;
     font-size: 80%;
     box-shadow: 0px 0px 0px rgba(0, 0, 0, 0);
+
+    code {
+      padding: 0px;
+    }
   }
 
   section img {
@@ -37,6 +42,11 @@ body {
 
   &.fade {
     opacity: 1;
+  }
+
+  .text_cell.rendered .rendered_html {
+    /* The H1 height seems miscalculated, we are just hidding the scrollbar */
+    overflow-y: hidden;
   }
 }
 

--- a/nbviewer/templates/nbconvert/slides_reveal.tpl
+++ b/nbviewer/templates/nbconvert/slides_reveal.tpl
@@ -1,0 +1,41 @@
+{%- extends 'basic.tpl' -%}
+
+{%- block any_cell scoped -%}
+{%- if cell.metadata.get('slide_start', False) -%}
+<section>
+{%- endif -%}
+{%- if cell.metadata.get('subslide_start', False) -%}
+<section>
+{%- endif -%}
+{%- if cell.metadata.get('fragment_start', False) -%}
+<div class="fragment">
+{%- endif -%}
+
+{%- if cell.metadata.slide_type == 'notes' -%}
+<aside class="notes">
+{{ super() }}
+</aside>
+{%- elif cell.metadata.slide_type == 'skip' -%}
+{%- else -%}
+{{ super() }}
+{%- endif -%}
+
+{%- if cell.metadata.get('fragment_end', False) -%}
+</div>
+{%- endif -%}
+{%- if cell.metadata.get('subslide_end', False) -%}
+</section>
+{%- endif -%}
+{%- if cell.metadata.get('slide_end', False) -%}
+</section>
+{%- endif -%}
+
+{%- endblock any_cell -%}
+
+{% block body %}
+<div class="reveal">
+<div class="slides">
+{{ super() }}
+</div>
+</div>
+{% endblock body %}

--- a/nbviewer/templates/nbconvert/slides_reveal.tpl
+++ b/nbviewer/templates/nbconvert/slides_reveal.tpl
@@ -1,35 +1,40 @@
 {%- extends 'basic.tpl' -%}
 
 {%- block any_cell scoped -%}
-{%- if cell.metadata.get('slide_start', False) -%}
-<section>
+{%- if cell.metadata.slide_type in ['slide'] -%}
+    <section>
+    <section>
+    {{ super() }}
+{%- elif cell.metadata.slide_type in ['subslide'] -%}
+    <section>
+    {{ super() }}
+{%- elif cell.metadata.slide_type in ['-'] -%}
+    {%- if cell.metadata.frag_helper in ['fragment_end'] -%}
+        <div class="fragment" data-fragment-index="{{ cell.metadata.frag_number }}">
+        {{ super() }}
+        </div>
+    {%- else -%}
+        {{ super() }}
+    {%- endif -%}
+{%- elif cell.metadata.slide_type in ['skip'] -%}
+    <div style=display:none>
+    {{ super() }}
+    </div>
+{%- elif cell.metadata.slide_type in ['notes'] -%}
+    <aside class="notes">
+    {{ super() }}
+    </aside>
+{%- elif cell.metadata.slide_type in ['fragment'] -%}
+    <div class="fragment" data-fragment-index="{{ cell.metadata.frag_number }}">
+    {{ super() }}
+    </div>
 {%- endif -%}
-{%- if cell.metadata.get('subslide_start', False) -%}
-<section>
+{%- if cell.metadata.slide_helper in ['subslide_end'] -%}
+    </section>
+{%- elif cell.metadata.slide_helper in ['slide_end'] -%}
+    </section>
+    </section>
 {%- endif -%}
-{%- if cell.metadata.get('fragment_start', False) -%}
-<div class="fragment">
-{%- endif -%}
-
-{%- if cell.metadata.slide_type == 'notes' -%}
-<aside class="notes">
-{{ super() }}
-</aside>
-{%- elif cell.metadata.slide_type == 'skip' -%}
-{%- else -%}
-{{ super() }}
-{%- endif -%}
-
-{%- if cell.metadata.get('fragment_end', False) -%}
-</div>
-{%- endif -%}
-{%- if cell.metadata.get('subslide_end', False) -%}
-</section>
-{%- endif -%}
-{%- if cell.metadata.get('slide_end', False) -%}
-</section>
-{%- endif -%}
-
 {%- endblock any_cell -%}
 
 {% block body %}


### PR DESCRIPTION
A resubmission of #511, but against the current pypi nbconvert (not master), to fix #506.

Adds a template path for nbconvert, the first use of which is used for a custom slides_reveal which just creates the body. This lets us get rid of the awful regex hack.

This is forked off of #508, whoops.