### PR TITLE
GitHub url sanitizing

### DIFF
--- a/nbviewer/tests/test_security.py
+++ b/nbviewer/tests/test_security.py
@@ -35,3 +35,14 @@ class LocalDirectoryTraversalTestCase(LFRPTC):
         url = self.url('localfile/../README.md')
         r = requests.get(url)
         self.assertEqual(r.status_code, 404)
+
+
+class URLLeakTestCase(NBViewerTestCase):
+    def test_gist(self):
+        url = self.url('/github/jupyter')
+        r = requests.get(url)
+        self.assertEqual(r.status_code, 200)
+        html = r.content
+        self.assertNotIn('client_id', html)
+        self.assertNotIn('client_secret', html)
+        self.assertNotIn('access_token', html)


### PR DESCRIPTION
The github auth tokens leak in URL params on certain pages with next/prev links.

This doesn't really impact any confidential data: some joker might use up our quota, as I assume that token doesn't do anything else, but that has to be about it. Would need to refresh the keys anyway!

This might be a thing that should be pushed up into the providers, but this seemed like the most expedient place to fix it.

cc @Carreau @rgbkrk 