### PR TITLE
manually calling bower

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,14 @@ ADD ./tasks.py /srv/nbviewer/
 # front-end dependencies
 ADD ["./nbviewer/static/bower.json", "./nbviewer/static/.bowerrc", \
      "/srv/nbviewer/nbviewer/static/"]
-RUN invoke bower
+
+# RUN invoke bower
+WORKDIR /srv/nbviewer/nbviewer/static
+RUN ../../node_modules/.bin/bower install \
+  --allow-root \
+  --config.interactive=false
+
+WORKDIR /srv/nbviewer
 
 # build css
 ADD . /srv/nbviewer/


### PR DESCRIPTION
Traceback for issue breaking the build for #494 below. Hooray, Unicode errors!

This just calls bower directly without using invoke. Doing some more local diagnostics to figure out where the issue lies (bower/invoke/us).

```python
Traceback (most recent call last):
  File "/usr/local/bin/invoke", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.4/dist-packages/invoke/cli.py", line 438, in main
    dispatch(sys.argv)
  File "/usr/local/lib/python3.4/dist-packages/invoke/cli.py", line 431, in dispatch
    return executor.execute(*tasks)
  File "/usr/local/lib/python3.4/dist-packages/invoke/executor.py", line 100, in execute
    task=task, name=name, args=args, kwargs=kwargs, config=config
  File "/usr/local/lib/python3.4/dist-packages/invoke/executor.py", line 153, in _execute
    result = task(*args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/invoke/tasks.py", line 111, in __call__
    result = self.body(*args, **kwargs)
  File "/srv/nbviewer/tasks.py", line 28, in bower
    " --config.interactive=false --allow-root"
  File "/usr/local/lib/python3.4/dist-packages/invoke/__init__.py", line 23, in run
    return Context().run(command, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/invoke/context.py", line 53, in run
    return runner_class(context=self).run(command, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/invoke/runners.py", line 262, in run
    raise ThreadException(exceptions)
invoke.exceptions.ThreadException: 
Saw 1 exceptions within threads (UnicodeEncodeError):


Thread args: {'args': [functools.partial(<built-in function read>, 4),
          <_io.TextIOWrapper name='<stdout>' mode='w' encoding='ANSI_X3.4-1968'>,
          ['bower bootstrap#~3.3        not-cached '
           'git://github.com/components/bootstrap.git#~3.3\n',
           'bower bootstrap#~3.3           resolve '
           'git://github.com/components/bootstrap.git#~3.3\n',
           'bower bootstrap#~3.3          download '
           'https://github.com/components/bootstrap/archive/3.3.5.tar.gz\n',
           'bower requirejs#~2.1        not-cached '
           'git://github.com/jrburke/requirejs-bower.git#~2.1\n',
           'bower requirejs#~2.1           resolve '
           'git://github.com/jrburke/requirejs-bower.git#~2.1\n',
           'bower headroom.js#0.7.0     not-cached '
           'git://github.com/WickyNilliams/headroom.js.git#0.7.0\n',
           'bower headroom.js#0.7.0        resolve '
           'git://github.com/WickyNilliams/headroom.js.git#0.7.0\n',
           'bower moment#~2.8.4         not-cached '
           'git://github.com/moment/moment.git#~2.8.4\n',
           'bower moment#~2.8.4            resolve '
           'git://github.com/moment/moment.git#~2.8.4\n',
           'bower font-awesome#~4       not-cached '
           'git://github.com/FortAwesome/Font-Awesome.git#~4\n',
           '<... remainder truncated during error display ...>'],
          False],
 'target': <bound method Local.io of <invoke.runners.Local object at 0x7fa1c9d2c278>>}

Traceback (most recent call last):

  File "/usr/local/lib/python3.4/dist-packages/invoke/runners.py", line 82, in run
    super(_IOThread, self).run()

  File "/usr/lib/python3.4/threading.py", line 868, in run
    self._target(*self._args, **self._kwargs)

  File "/usr/local/lib/python3.4/dist-packages/invoke/runners.py", line 328, in io
    output.write(data)

UnicodeEncodeError: 'ascii' codec can't encode characters in position 119-127: ordinal not in range(128)


```