### PR TITLE
Fix recent 503 errors

### DIFF
--- a/nbviewer/log.py
+++ b/nbviewer/log.py
@@ -49,6 +49,6 @@ def log_request(handler):
         msg = msg + ' user-agent={agent}'
     if status >= 500 and status != 502:
         # log all headers if it caused an error
-        log_method(json.dumps(request.headers, indent=2))
+        log_method(json.dumps(dict(request.headers), indent=2))
     log_method(msg.format(**ns))
 

--- a/nbviewer/providers/github/client.py
+++ b/nbviewer/providers/github/client.py
@@ -69,6 +69,9 @@ class AsyncGitHubClient(object):
             r = future.result()
         except HTTPError as e:
             r = e.response
+            if r is None:
+                # some errors don't have a response (e.g. failure to build request)
+                return
         limit_s = r.headers.get('X-RateLimit-Limit', '')
         remaining_s = r.headers.get('X-RateLimit-Remaining', '')
         if not remaining_s or not limit_s:

--- a/nbviewer/providers/github/client.py
+++ b/nbviewer/providers/github/client.py
@@ -74,7 +74,7 @@ class AsyncGitHubClient(object):
         if not remaining_s or not limit_s:
             if r.code < 300:
                 app_log.warn("No rate limit headers. Did GitHub change? %s",
-                    json.dumps(r.headers, indent=1)
+                    json.dumps(dict(r.headers), indent=1)
                 )
             return
         

--- a/nbviewer/providers/github/client.py
+++ b/nbviewer/providers/github/client.py
@@ -98,7 +98,7 @@ class AsyncGitHubClient(object):
         URL is constructed from url and params, if specified.
         callback and **kwargs are passed to client.fetch unmodified.
         """
-        url = url_path_join(self.github_api_url, path)
+        url = url_path_join(self.github_api_url, quote(path))
         return self.fetch(url, callback, **kwargs)
 
     def get_gist(self, gist_id, callback=None, **kwargs):
@@ -108,9 +108,7 @@ class AsyncGitHubClient(object):
     
     def get_contents(self, user, repo, path, callback=None, ref=None, **kwargs):
         """Make contents API request - either file contents or directory listing"""
-        path = quote(u'repos/{user}/{repo}/contents/{path}'.format(
-            **locals()
-        ))
+        path = u'repos/{user}/{repo}/contents/{path}'.format(**locals())
         if ref is not None:
             params = kwargs.setdefault('params', {})
             params['ref'] = ref


### PR DESCRIPTION
The root cause is actually tornadoweb/tornado#1582, where failure to construct requests could eventually prevent future requests from ever being made. On our side, this was caused by failure to quote GitHub paths, which resulted in UnicodeEncodeErrors in PyCurl. Once 10 requests had been made to non-ascii GitHub URLs, no subsequent requests would ever be made.

While digging into this, I reworked how we wait for concurrent requests by using Futures, and fixed a few bugs in our logging of failed requests.

closes #534