### PR TITLE
Testing fixes

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -222,6 +222,10 @@ def make_app():
 
 def init_options():
     # command-line options
+    if 'port' in options:
+        # already run
+        return
+    
     define("debug", default=False, help="run in debug mode", type=bool)
     define("no_cache", default=False, help="Do not cache results", type=bool)
     define("localfiles", default="", help="Allow to serve local files under /localfile/* this can be a security risk", type=str)
@@ -242,9 +246,9 @@ def init_options():
     define("mathjax_url", default="https://cdn.mathjax.org/mathjax/latest/", help="URL base for mathjax package", type=str)
 
 
-def main():
+def main(argv=None):
     init_options()
-    tornado.options.parse_command_line()
+    tornado.options.parse_command_line(argv)
 
     # create and start the app
     app = make_app()
@@ -260,7 +264,7 @@ def main():
     http_server = httpserver.HTTPServer(app, xheaders=True, ssl_options=ssl_options)
     log.app_log.info("Listening on port %i", options.port)
     http_server.listen(options.port)
-    ioloop.IOLoop.instance().start()
+    ioloop.IOLoop.current().start()
 
 
 if __name__ == '__main__':

--- a/nbviewer/providers/local/tests/test_localfile.py
+++ b/nbviewer/providers/local/tests/test_localfile.py
@@ -13,10 +13,8 @@ from ....tests.base import NBViewerTestCase, FormatHTMLMixin
 
 class LocalFileDefaultTestCase(NBViewerTestCase):
     @classmethod
-    def get_server_cmd(cls):
+    def get_server_args(cls):
         return [
-            sys.executable, '-m', 'nbviewer',
-            '--port=%d' % cls.port,
             '--localfiles=.',
             ]
 
@@ -34,10 +32,8 @@ class FormatHTMLLocalFileDefaultTestCase(LocalFileDefaultTestCase,
 
 class LocalFileRelativePathTestCase(NBViewerTestCase):
     @classmethod
-    def get_server_cmd(cls):
+    def get_server_args(cls):
         return [
-            sys.executable, '-m', 'nbviewer',
-            '--port=%d' % cls.port,
             '--localfiles=nbviewer',
             ]
 

--- a/nbviewer/tests/test_format_slides.py
+++ b/nbviewer/tests/test_format_slides.py
@@ -13,22 +13,22 @@ from ..providers.local.tests.test_localfile import LocalFileDefaultTestCase
 
 class SlidesGistTestCase(NBViewerTestCase):
     def test_gist(self):
-        url = self.url('/format/slides/7518294/Untitled0.ipynb')
+        url = self.url('/format/slides/0c5b3639b10ed3d7cc85/single-cell.ipynb')
         r = requests.get(url)
         self.assertEqual(r.status_code, 200)
         html = r.content
         self.assertIn('reveal.js', html)
 
     def test_html_exporter_link(self):
-        url = self.url('/format/slides/7518294/Untitled0.ipynb')
+        url = self.url('/format/slides/0c5b3639b10ed3d7cc85/single-cell.ipynb')
         r = requests.get(url)
         self.assertEqual(r.status_code, 200)
         html = r.content
-        self.assertIn('/gist/minrk/7518294/Untitled0.ipynb', html)
-        self.assertNotIn('//gist/minrk/7518294/Untitled0.ipynb', html)
+        self.assertIn('/gist/minrk/0c5b3639b10ed3d7cc85/single-cell.ipynb', html)
+        self.assertNotIn('//gist/minrk/0c5b3639b10ed3d7cc85/single-cell.ipynb', html)
 
     def test_no_slides_exporter_link(self):
-        url = self.url('/7518294/Untitled0.ipynb')
+        url = self.url('/0c5b3639b10ed3d7cc85/single-cell.ipynb')
         r = requests.get(url)
         self.assertEqual(r.status_code, 200)
         html = r.content


### PR DESCRIPTION
- slides export can't handle empty notebooks, so use a notebook with a single markdown cell.
- run nbviewer test instance in a thread instead of a subprocess, which means we will get nice log capturing when tests fail, which makes fixing issues like the above a lot easier.