### PR TITLE
bring slides up-to-date with nbconvert 4.1

### DIFF
--- a/nbviewer/templates/nbconvert/slides_reveal.tpl
+++ b/nbviewer/templates/nbconvert/slides_reveal.tpl
@@ -1,46 +1,42 @@
 {%- extends 'basic.tpl' -%}
 
+
 {%- block any_cell scoped -%}
-{%- if cell.metadata.slide_type in ['slide'] -%}
-    <section>
-    <section>
-    {{ super() }}
-{%- elif cell.metadata.slide_type in ['subslide'] -%}
-    <section>
-    {{ super() }}
-{%- elif cell.metadata.slide_type in ['-'] -%}
-    {%- if cell.metadata.frag_helper in ['fragment_end'] -%}
-        <div class="fragment" data-fragment-index="{{ cell.metadata.frag_number }}">
-        {{ super() }}
-        </div>
-    {%- else -%}
-        {{ super() }}
-    {%- endif -%}
-{%- elif cell.metadata.slide_type in ['skip'] -%}
-    <div style=display:none>
-    {{ super() }}
-    </div>
-{%- elif cell.metadata.slide_type in ['notes'] -%}
-    <aside class="notes">
-    {{ super() }}
-    </aside>
-{%- elif cell.metadata.slide_type in ['fragment'] -%}
-    <div class="fragment" data-fragment-index="{{ cell.metadata.frag_number }}">
-    {{ super() }}
-    </div>
-{%- endif -%}
-{%- if cell.metadata.slide_helper in ['subslide_end'] -%}
-    </section>
-{%- elif cell.metadata.slide_helper in ['slide_end'] -%}
-    </section>
-    </section>
-{%- endif -%}
+  {%- if cell.metadata.get('slide_start', False) -%}
+  <section>
+  {%- endif -%}
+  {%- if cell.metadata.get('subslide_start', False) -%}
+  <section>
+  {%- endif -%}
+  {%- if cell.metadata.get('fragment_start', False) -%}
+  <div class="fragment">
+  {%- endif -%}
+
+  {%- if cell.metadata.slide_type == 'notes' -%}
+  <aside class="notes">
+  {{ super() }}
+  </aside>
+  {%- elif cell.metadata.slide_type == 'skip' -%}
+  {%- else -%}
+  {{ super() }}
+  {%- endif -%}
+
+  {%- if cell.metadata.get('fragment_end', False) -%}
+  </div>
+  {%- endif -%}
+  {%- if cell.metadata.get('subslide_end', False) -%}
+  </section>
+  {%- endif -%}
+  {%- if cell.metadata.get('slide_end', False) -%}
+  </section>
+  {%- endif -%}
 {%- endblock any_cell -%}
 
+
 {% block body %}
-<div class="reveal">
-<div class="slides">
-{{ super() }}
-</div>
-</div>
+  <div class="reveal">
+  <div class="slides">
+  {{ super() }}
+  </div>
+  </div>
 {% endblock body %}


### PR DESCRIPTION
This fixes #543 by bringing basically reverting to the middle commit of #512. Wasn't paying attention to the nbconvert release cycle, where a bunch of the slide stuff got fixed.

I've checked this out in Docker, looks solid.