### PR TITLE
pop pending futures when they are done

### DIFF
--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -451,6 +451,7 @@ def cached(method):
                 # call the wrapped method
                 yield method(self, *args, **kwargs)
             finally:
+                self.pending.pop(uri, None)
                 # notify waiters
                 future.set_result(None)
 


### PR DESCRIPTION
we've been triggering 'Waited 0.00s for concurrent request' on every non-unique request for a while now.