### PR TITLE
Support rendering of .snb files

### DIFF
--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -56,7 +56,7 @@ except ImportError:
 
 date_fmt = "%a, %d %b %Y %H:%M:%S UTC"
 format_prefix = "/format/"
-
+notebook_file_extensions = ['.ipynb', '.snb']
 
 class BaseHandler(web.RequestHandler):
     """Base Handler class with common utilities"""
@@ -175,6 +175,13 @@ class BaseHandler(web.RequestHandler):
                 'name' : name,
             })
         return breadcrumbs
+
+    def is_notebook_file(self, path):
+        """return if a path is a notebook file
+
+        It checks for presence of file extension, such as '.ipynb'.
+        """
+        return any(path.endswith(ext) for ext in notebook_file_extensions)
 
     def get_page_links(self, response):
         """return prev_url, next_url for pagination

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -167,7 +167,7 @@ class GitHubTreeHandler(GithubClientMixin, BaseHandler):
                 e['url'] = quote(e['url'])
                 e['class'] = 'fa-folder-open'
                 dirs.append(e)
-            elif file['name'].endswith('.ipynb'):
+            elif self.is_notebook_file(file['name']):
                 e['url'] = u'/github/{user}/{repo}/blob/{ref}/{path}'.format(
                 user=user, repo=repo, ref=ref, path=file['path']
                 )
@@ -256,7 +256,7 @@ class GitHubBlobHandler(GithubClientMixin, RenderingHandler):
             # filedata will be unicode
             filedata = contents
 
-        if path.endswith('.ipynb'):
+        if self.is_notebook_file(path):
             dir_path = path.rsplit('/', 1)[0]
             base_url = "/github/{user}/{repo}/tree/{ref}".format(
                 user=user, repo=repo, ref=ref,

--- a/nbviewer/providers/url/handlers.py
+++ b/nbviewer/providers/url/handlers.py
@@ -49,7 +49,7 @@ class URLHandler(RenderingHandler):
 
         if query:
             remote_url = remote_url + '?' + query
-        if not url.endswith('.ipynb'):
+        if not self.is_notebook_file(url):
             # this is how we handle relative links (files/ URLs) in notebooks
             # if it's not a .ipynb URL and it is a link from a notebook,
             # redirect to the original URL rather than trying to render it as a notebook


### PR DESCRIPTION
- [x] fix rendering
- [x] fix github fetching
- [x] configurable list of supported extentions

I'm sure guys from https://github.com/andypetrella/spark-notebook and https://github.com/Bridgewater/scala-notebook will be extremely excited.
At the moment their notebook format is 100% compatible with `ipynb`.

this tiny fix already renders fine github urls:
- lists available files, and links to .snb notebooks become active/clickable/renderable `http://docker:8080/github/andypetrella/spark-notebook/blob/master/notebooks`
- renders snb notebook: `http://docker:8080/github/andypetrella/spark-notebook/blob/master/notebooks/Flow%20Example.snb`


<img width="600" alt="screen shot 2016-02-05 at 12 41 37" src="https://cloud.githubusercontent.com/assets/213426/12844072/de2c898a-cc05-11e5-90fd-929fcb75da44.png">

