### PR TITLE
Cache upstream responses

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -42,9 +42,9 @@ from .providers import default_providers, default_rewrites
 from .providers.local import LocalFileHandler
 
 try:
-    from .providers.url.client import LoggingCurlAsyncHTTPClient as HTTPClientClass
+    from .providers.url.client import NBViewerCurlAsyncHTTPClient as HTTPClientClass
 except ImportError:
-    from .providers.url.client import LoggingSimpleAsyncHTTPClient as HTTPClientClass
+    from .providers.url.client import NBViewerSimpleAsyncHTTPClient as HTTPClientClass
 
 
 from .log import log_request
@@ -175,6 +175,7 @@ def make_app():
     )
     AsyncHTTPClient.configure(HTTPClientClass)
     client = AsyncHTTPClient()
+    client.cache = cache
 
     # load frontpage sections
     with io.open(options.frontpage, 'r') as f:

--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -196,7 +196,10 @@ class BaseHandler(web.RequestHandler):
     #---------------------------------------------------------------
 
     def client_error_message(self, exc, url, body, msg=None):
-        """Turn the tornado HTTP error into something useful"""
+        """Turn the tornado HTTP error into something useful
+        
+        Returns error code
+        """
         str_exc = str(exc)
 
         # strip the unhelpful 599 prefix
@@ -206,8 +209,32 @@ class BaseHandler(web.RequestHandler):
         if (msg is None) and body and len(body) < 100:
             # if it's a short plain-text error message, include it
             msg = "%s (%s)" % (str_exc, escape(body))
-
-        return msg or str_exc
+        
+        if not msg:
+            msg = str_exc
+        
+        # Now get the error code
+        if exc.code == 599:
+            if isinstance(exc, CurlError):
+                en = getattr(exc, 'errno', -1)
+                # can't connect to server should be 404
+                # possibly more here
+                if en in (pycurl.E_COULDNT_CONNECT, pycurl.E_COULDNT_RESOLVE_HOST):
+                    code = 404
+            # otherwise, raise 400 with informative message:
+            code = 400
+        elif exc.code >= 500:
+            # 5XX, server error, but not this server
+            code = 502
+        else:
+            # client-side error, blame our client
+            if exc.code == 404:
+                code = 404
+                msg = "Remote %s" % msg
+            else:
+                code = 400
+        
+        return code, msg
 
     def reraise_client_error(self, exc):
         """Remote fetch raised an error"""
@@ -218,29 +245,12 @@ class BaseHandler(web.RequestHandler):
             url = 'url'
             body = ''
 
-        msg = self.client_error_message(exc, url, body)
+        code, msg = self.client_error_message(exc, url, body)
 
         slim_body = escape(body[:300])
 
         app_log.warn("Fetching %s failed with %s. Body=%s", url, msg, slim_body)
-        if exc.code == 599:
-            if isinstance(exc, CurlError):
-                en = getattr(exc, 'errno', -1)
-                # can't connect to server should be 404
-                # possibly more here
-                if en in (pycurl.E_COULDNT_CONNECT, pycurl.E_COULDNT_RESOLVE_HOST):
-                    raise web.HTTPError(404, msg)
-            # otherwise, raise 400 with informative message:
-            raise web.HTTPError(400, msg)
-        if exc.code >= 500:
-            # 5XX, server error, but not this server
-            raise web.HTTPError(502, msg)
-        else:
-            # client-side error, blame our client
-            if exc.code == 404:
-                raise web.HTTPError(404, "Remote %s" % msg)
-            else:
-                raise web.HTTPError(400, msg)
+        raise web.HTTPError(code, msg)
 
     @contextmanager
     def catch_client_error(self):

--- a/nbviewer/providers/gist/handlers.py
+++ b/nbviewer/providers/gist/handlers.py
@@ -34,8 +34,8 @@ PROVIDER_CTX = {
 
 class GistClientMixin(GithubClientMixin):
     def client_error_message(self, exc, url, body, msg=None):
-        if exc.code == 403 and 'too big' in body:
-            msg = "GitHub will not serve raw gists larger than 10MB"
+        if exc.code == 403 and 'too big' in body.lower():
+            return 400, "GitHub will not serve raw gists larger than 10MB"
 
         return super(GistClientMixin, self).client_error_message(
             exc, url, body, msg

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -45,6 +45,14 @@ class GithubClientMixin(object):
         if getattr(self, "_github_client", None) is None:
             self._github_client = AsyncGitHubClient(self.client)
         return self._github_client
+    
+    def client_error_message(self, exc, url, body, msg=None):
+        if exc.code == 403 and 'rate limit' in body.lower():
+            return 503, "GitHub API rate limit exceeded. Try again soon."
+
+        return super(GithubClientMixin, self).client_error_message(
+            exc, url, body, msg
+        )
 
 
 class RawGitHubURLHandler(BaseHandler):

--- a/nbviewer/providers/url/client.py
+++ b/nbviewer/providers/url/client.py
@@ -1,9 +1,11 @@
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
+"""Async HTTP client with bonus features!
+
+- Support caching via upstream 304 with ETag, Last-Modified
+- Log request timings for profiling
+"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import hashlib
 import pickle
@@ -14,8 +16,10 @@ from tornado.log import app_log
 
 from tornado import gen
 
+from nbviewer.utils import time_block
+
 #-----------------------------------------------------------------------------
-# Async GitHub Client
+# Async HTTP Client
 #-----------------------------------------------------------------------------
 
 # cache headers and their response:request mapping
@@ -28,77 +32,95 @@ cache_headers = {
 }
 
 class NBViewerAsyncHTTPClient(object):
-    """Subclass of AsyncHTTPClient with bonus logging and caching!"""
+    """Subclass of AsyncHTTPClient with bonus logging and caching!
     
-    def __init__(self, cache=None):
-        self.cache = cache
+    If upstream servers support 304 cache replies with the following headers:
+    
+    - ETag : If-None-Match
+    - Last-Modified : If-Modified-Since
+    
+    Upstream requests are still made every time,
+    but resources and rate limits may be saved by 304 responses.
+    
+    Currently, responses are cached for a non-configurable two hours.
+    """
+    
+    cache = None
+    expiry = 7200
     
     def fetch_impl(self, request, callback):
-        self.io_loop.add_callback(lambda : self._cached_fetch(request, callback))
+        self.io_loop.add_callback(lambda : self._fetch_impl(request, callback))
     
     @gen.coroutine
-    def _cached_fetch(self, request, callback):
+    def _fetch_impl(self, request, callback):
         tic = time.time()
         if request.user_agent is None:
             request.user_agent = 'Tornado-Async-Client'
-
-        without_params = request.url.split('?')[0]
+        
+        # when logging, use the URL without params
+        name = request.url.split('?')[0]
         cached_response = None
-        app_log.debug("Fetching %s", without_params)
+        app_log.debug("Fetching %s", name)
         cache_key = hashlib.sha256(request.url.encode('utf8')).hexdigest()
-        if self.cache:
-            cache_tic = time.time()
-            try:
-                cached_pickle = yield self.cache.get(cache_key)
-                if cached_pickle:
-                    cached_response = pickle.loads(cached_pickle)
-            except Exception:
-                app_log.error("Failed to get cached response for %s",
-                    without_params, exc_info=True)
+        with time_block("Upstream cache get %s" % name):
+            cached_response = yield self._get_cached_response(cache_key, name)
+        
         if cached_response:
-            app_log.info("Have cached response for %s", without_params)
-            dt = time.time() - cache_tic
-            app_log.debug("Upstream response cache hit for %s in %.2f ms",
-                without_params, 1e3 * dt)
+            app_log.debug("Upstream cache hit %s", name)
             # add cache headers, if any
             for resp_key, req_key in cache_headers.items():
                 value = cached_response.headers.get(resp_key)
                 if value:
                     request.headers[req_key] = value
+        else:
+            app_log.debug("Upstream cache miss %s", name)
         
-        @gen.coroutine
-        def finish(response):
-            dt = time.time() - tic
-            log = app_log.info if dt > 1 else app_log.debug
-            if response.code == 304 and cached_response:
-                log("Upstream 304 on %s in %.2f ms", without_params, 1e3 * dt)
-                callback(cached_response)
-            else:
-                if not response.error:
-                    log("Fetched  %s in %.2f ms", without_params, 1e3 * dt)
-                callback(response)
-                if self.cache:
-                    yield self.cache_response(response)
-                yield self.
-                if self.cache and not response.error and any(response.headers.get(key) for key in cache_headers):
-                    # cache for two hours if there are any cache headers (use cache expiry?)
-                    cache_tic = time.time()
-                    expiry = 7200
-                    try:
-                        pickle_response = pickle.dumps(response, pickle.HIGHEST_PROTOCOL)
-                        yield self.cache.set(
-                            cache_key,
-                            pickle_response,
-                            int(time.time() + expiry),
-                        )
-                    except Exception:
-                        app_log.error("Failed to cache response for %s" % without_params, exc_info=True)
-                    else:
-                        dt = time.time() - cache_tic
-                        app_log.debug("Cached upstream response for %s in %.2f ms",
-                            without_params, 1e3 * dt)
-        
-        super(NBViewerAsyncHTTPClient, self).fetch_impl(request, finish)
+        response = yield gen.Task(super(NBViewerAsyncHTTPClient, self).fetch_impl, request)
+        dt = time.time() - tic
+        log = app_log.info if dt > 1 else app_log.debug
+        if response.code == 304 and cached_response:
+            log("Upstream 304 on %s in %.2f ms", name, 1e3 * dt)
+            callback(cached_response)
+        else:
+            if not response.error:
+                log("Fetched  %s in %.2f ms", name, 1e3 * dt)
+            callback(response)
+            if not response.error:
+                yield self._cache_response(cache_key, name, response)
+    
+    @gen.coroutine
+    def _get_cached_response(self, cache_key, name):
+        """Get the cached response, if any"""
+        if not self.cache:
+            return
+        try:
+            cached_pickle = yield self.cache.get(cache_key)
+            if cached_pickle:
+                raise gen.Return(pickle.loads(cached_pickle))
+        except gen.Return:
+            raise # FIXME: remove gen.Return when we drop py2 support
+        except Exception:
+            app_log.error("Upstream cache get failed %s", name, exc_info=True)
+    
+    @gen.coroutine
+    def _cache_response(self, cache_key, name, response):
+        """Cache the response, if any cache headers we understand are present."""
+        if not self.cache:
+            return
+        if not any(response.headers.get(key) for key in cache_headers):
+            # no cache headers, no point in caching the response
+            return
+        with time_block("Upstream cache set %s" % name):
+            # cache the response if there are any cache headers (use cache expiry?)
+            try:
+                pickle_response = pickle.dumps(response, pickle.HIGHEST_PROTOCOL)
+                yield self.cache.set(
+                    cache_key,
+                    pickle_response,
+                    int(time.time() + self.expiry),
+                )
+            except Exception:
+                app_log.error("Upstream cache failed %s" % name, exc_info=True)
 
 
 class NBViewerSimpleAsyncHTTPClient(NBViewerAsyncHTTPClient, SimpleAsyncHTTPClient):

--- a/nbviewer/providers/url/client.py
+++ b/nbviewer/providers/url/client.py
@@ -5,34 +5,103 @@
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 
+import hashlib
+import pickle
 import time
 
 from tornado.simple_httpclient import SimpleAsyncHTTPClient
 from tornado.log import app_log
 
+from tornado import gen
+
 #-----------------------------------------------------------------------------
 # Async GitHub Client
 #-----------------------------------------------------------------------------
 
-class LoggingAsyncHTTPClient(object):
-    """Subclass of AsyncHTTPClient with bonus logging!"""
+# cache headers and their response:request mapping
+# use this to map headers in cached response to the headers
+# that should be set in the request.
+
+cache_headers = {
+    'ETag': 'If-None-Match',
+    'Last-Modified': 'If-Modified-Since',
+}
+
+class NBViewerAsyncHTTPClient(object):
+    """Subclass of AsyncHTTPClient with bonus logging and caching!"""
+    
+    def __init__(self, cache=None):
+        self.cache = cache
     
     def fetch_impl(self, request, callback):
-        without_params = request.url.split('?')[0]
-        app_log.debug("Fetching %s", without_params)
+        self.io_loop.add_callback(lambda : self._cached_fetch(request, callback))
+    
+    @gen.coroutine
+    def _cached_fetch(self, request, callback):
         tic = time.time()
         if request.user_agent is None:
             request.user_agent = 'Tornado-Async-Client'
 
-        def log_callback(result):
-            if not result.error:
-                dt = time.time() - tic
-                log = app_log.info if dt > 1 else app_log.debug
-                log("Fetched  %s in %.2f ms", without_params, 1e3 * dt)
-            callback(result)
-        return super(LoggingAsyncHTTPClient, self).fetch_impl(request, log_callback)
-    
-class LoggingSimpleAsyncHTTPClient(LoggingAsyncHTTPClient, SimpleAsyncHTTPClient):
+        without_params = request.url.split('?')[0]
+        cached_response = None
+        app_log.debug("Fetching %s", without_params)
+        cache_key = hashlib.sha256(request.url.encode('utf8')).hexdigest()
+        if self.cache:
+            cache_tic = time.time()
+            try:
+                cached_pickle = yield self.cache.get(cache_key)
+                if cached_pickle:
+                    cached_response = pickle.loads(cached_pickle)
+            except Exception:
+                app_log.error("Failed to get cached response for %s",
+                    without_params, exc_info=True)
+        if cached_response:
+            app_log.info("Have cached response for %s", without_params)
+            dt = time.time() - cache_tic
+            app_log.debug("Upstream response cache hit for %s in %.2f ms",
+                without_params, 1e3 * dt)
+            # add cache headers, if any
+            for resp_key, req_key in cache_headers.items():
+                value = cached_response.headers.get(resp_key)
+                if value:
+                    request.headers[req_key] = value
+        
+        @gen.coroutine
+        def finish(response):
+            dt = time.time() - tic
+            log = app_log.info if dt > 1 else app_log.debug
+            if response.code == 304 and cached_response:
+                log("Upstream 304 on %s in %.2f ms", without_params, 1e3 * dt)
+                callback(cached_response)
+            else:
+                if not response.error:
+                    log("Fetched  %s in %.2f ms", without_params, 1e3 * dt)
+                callback(response)
+                if self.cache:
+                    yield self.cache_response(response)
+                yield self.
+                if self.cache and not response.error and any(response.headers.get(key) for key in cache_headers):
+                    # cache for two hours if there are any cache headers (use cache expiry?)
+                    cache_tic = time.time()
+                    expiry = 7200
+                    try:
+                        pickle_response = pickle.dumps(response, pickle.HIGHEST_PROTOCOL)
+                        yield self.cache.set(
+                            cache_key,
+                            pickle_response,
+                            int(time.time() + expiry),
+                        )
+                    except Exception:
+                        app_log.error("Failed to cache response for %s" % without_params, exc_info=True)
+                    else:
+                        dt = time.time() - cache_tic
+                        app_log.debug("Cached upstream response for %s in %.2f ms",
+                            without_params, 1e3 * dt)
+        
+        super(NBViewerAsyncHTTPClient, self).fetch_impl(request, finish)
+
+
+class NBViewerSimpleAsyncHTTPClient(NBViewerAsyncHTTPClient, SimpleAsyncHTTPClient):
     pass
 
 try:
@@ -40,6 +109,6 @@ try:
 except ImportError:
     pass
 else:
-    class LoggingCurlAsyncHTTPClient(LoggingAsyncHTTPClient, CurlAsyncHTTPClient):
+    class NBViewerCurlAsyncHTTPClient(NBViewerAsyncHTTPClient, CurlAsyncHTTPClient):
         pass
 

--- a/nbviewer/templates/error.html
+++ b/nbviewer/templates/error.html
@@ -8,6 +8,9 @@
       <h1>{{status_code}} : {{status_message}}</h1>
       {% endblock h1_error %}
       {% block error_detail %}
+      {% if message %}
+      <p>{{message}}</p>
+      {% endif %}
       {% endblock %}
     </div>
   </header>

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -14,8 +14,10 @@ except ImportError:
     from base64 import decodestring as decodebytes
 
 import cgi
+from contextlib import contextmanager
 import re
 from subprocess import check_output
+import time
 
 try:
     from urllib.parse import (
@@ -35,6 +37,7 @@ except ImportError:
     )
 
 
+from tornado.log import app_log
 from IPython.utils import py3compat
 
 
@@ -222,3 +225,17 @@ def base64_encode(s):
     s = py3compat.cast_bytes(s)
     encoded = encodebytes(s)
     return encoded.decode('ascii')
+
+
+@contextmanager
+def time_block(message):
+    """context manager for timing a block
+
+    logs millisecond timings of the block
+    """
+    tic = time.time()
+    yield
+    dt = time.time() - tic
+    log = app_log.info if dt > 1 else app_log.debug
+    log("%s in %.2f ms", message, 1e3 * dt)
+


### PR DESCRIPTION
For servers that support If-None-Matching, If-Modified-Since cache headers, lean on upstream 304 responses for cache hit detection.

If an upstream request gives 304, the cached response is re-used.

Cached responses are saved for a hardcoded two hours, for now. Since we only support 304-based cache detection, a long expiry should not be a problem.

Since the GitHub API uses these headers and 304 responses don't count against your rate limit, this should significantly improve our rate limit consumption.

I also changed the error message when GitHub requests are failing due to the rate limit, so instead of a 400 with opaque "The error was: 403", it is a 503 error and explicitly mentions the GitHub rate limit and come back later.

closes #564