### PR TITLE
[wip] binder button

### DIFF
--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -506,9 +506,11 @@ class RenderingHandler(BaseHandler):
                 app_log.info("failed to test %s: %s", self.request.uri, name)
 
     @gen.coroutine
-    def finish_notebook(self, json_notebook, download_url, provider_url=None, 
+    def finish_notebook(self, json_notebook, download_url, provider_url=None,
                         provider_icon=None, provider_label=None, msg=None,
-                        breadcrumbs=None, public=False, format=None, request=None):
+                        breadcrumbs=None, public=False, format=None,
+                        runner_icon=None, runner_label=None, runner_url=None,
+                        request=None):
         """render a notebook from its JSON body.
 
         download_url is required, provider_url is not.
@@ -550,6 +552,9 @@ class RenderingHandler(BaseHandler):
             provider_url=provider_url,
             provider_label=provider_label,
             provider_icon=provider_icon,
+            runner_url=runner_url,
+            runner_label=runner_label,
+            runner_icon=runner_icon,
             format=self.format,
             default_format=self.default_format,
             format_prefix=format_prefix,

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -35,8 +35,11 @@ from .client import AsyncGitHubClient
 PROVIDER_CTX = {
     'provider_label': 'GitHub',
     'provider_icon': 'github',
+    'runner_icon': 'play-circle-o',
+    'runner_label': 'Binder'
 }
 
+BINDER_TMPL = u"http://mybinder.org/repo/{user}/{repo}"
 
 class GithubClientMixin(object):
     @property
@@ -196,12 +199,18 @@ class GitHubTreeHandler(GithubClientMixin, BaseHandler):
         entries.extend(dirs)
         entries.extend(ipynbs)
         entries.extend(others)
+        
+        # TODO: this needs to be a (cached, async) API call
+        runner_url = None
+        if True:
+            runner_url = BINDER_TMPL.format(user=user, repo=repo)
 
         html = self.render_template("treelist.html",
             entries=entries, breadcrumbs=breadcrumbs, provider_url=provider_url,
             user=user, repo=repo, ref=ref, path=path,
             branches=branches, tags=tags, tree_type="github",
             tree_label="repositories",
+            runner_url=runner_url,
             **PROVIDER_CTX
         )
         yield self.cache_and_finish(html)
@@ -275,6 +284,11 @@ class GitHubBlobHandler(GithubClientMixin, RenderingHandler):
             }]
             breadcrumbs.extend(self.breadcrumbs(dir_path, base_url))
 
+            # TODO: this needs to be a (cached, async) API call
+            runner_url = None
+            if True:
+                runner_url = BINDER_TMPL.format(user=user, repo=repo)
+
             try:
                 # filedata may be bytes, but we need text
                 if isinstance(filedata, bytes):
@@ -291,6 +305,7 @@ class GitHubBlobHandler(GithubClientMixin, RenderingHandler):
                 public=True,
                 format=self.format,
                 request=self.request,
+                runner_url=runner_url,
                 **PROVIDER_CTX
             )
         else:

--- a/nbviewer/providers/github/tests/test_runners.py
+++ b/nbviewer/providers/github/tests/test_runners.py
@@ -1,0 +1,37 @@
+import requests
+
+from ....tests.base import NBViewerTestCase
+
+
+class BinderRunnerTestCase(NBViewerTestCase):
+    def test_tree_has_binder(self):
+        url = self.url('github/binder-project/example-requirements')
+        r = requests.get(url)
+        self.assertEqual(r.status_code, 200)
+        html = r.text
+        self.assertIn(
+            'http://mybinder.org/repo/binder-project/example-requirements',
+            html,
+            "a binder URL appears on the page")
+
+    def test_tree_has_no_binder(self):
+        """Assumes binder cannot be build on binder"""
+        url = self.url('github/binder-project/binder')
+        r = requests.get(url)
+        self.assertEqual(r.status_code, 200)
+        html = r.text
+        self.assertNotIn(
+            'http://mybinder.org/repo/binder-project/binder',
+            html,
+            "a binder URL DOES NOT appears on the page")
+
+    def test_notebook_has_binder(self):
+        url = self.url('github/binder-project/example-requirements/'
+                       'blob/master/index.ipynb')
+        r = requests.get(url)
+        self.assertEqual(r.status_code, 200)
+        html = r.text
+        self.assertIn(
+            'http://mybinder.org/repo/binder-project/example-requirements',
+            html,
+            "a binder URL appears on the page")

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -100,12 +100,12 @@
           {{ head_text('/faq', "FAQ") }}
 
           {% block otherlinks %}
+            {% if runner_url %}
+              {{ head_icon(runner_url, "Run on " + runner_label, runner_icon) }}
+            {% endif %}
+
             {% if provider_url %}
-              <li>
-                <a href="{{provider_url}}" title="View on {{provider_label}}">
-                  <i class="fa fa-{{provider_icon}} fa-2x menu-icon"></i>
-                </a>
-              </li>
+              {{ head_icon(provider_url, "View on " + provider_label, provider_icon) }}
             {% endif %}
           {% endblock %}
         </ul>

--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -18,11 +18,9 @@
     {{ layout.head_icon("#", nb.metadata.kernelspec.display_name + " Kernel", "server") }}
   {% endif %}
 
-  {% if provider_url %}
-    {{ layout.head_icon(provider_url, "View on " + provider_label, provider_icon) }}
-  {% endif %}
-
   {{ layout.head_icon(download_url, "Download Notebook", "download", True) }}
+
+  {{ super() }}
 {% endblock %}
 
 


### PR DESCRIPTION
Hooray #585! :tada: I have wanted to see this since the original announcement, great news @Carreau (and, of course, @freeman-lab, @andrewosh, @rgbkrk). Had to throw something down quick! Screenshots at the bottom!

### What is done?
This is the simplest jinja/tornado stuff I could think of to add a binder button to the github provider. Since (at least in my current understanding) a binder either exists or not for a whole _repo_, not an individual notebook, I'm showing it on both the notebook page and the repo tree list.

I've added some minimal failing tests... instead of never showing the button (since we can't hit an API yet), it just always shows the button. The failing test is for a project that probably won't have a binder... namely binder itself.

### What might we do/discuss next?
- [ ] pick icons
- [ ] need to know the API endpoint, once it's a available
- [ ] cached, async client request to determine whether there is binder or not
  - [ ] will we need an API key or something?
- [ ] in the case of a notebook, can we deep-link directly to it?
  - otherwise the user will have to navigate first in nbviewer, then again in the repo... which might be obstructed by the automatic index.ipynb loading, etc.

### What else could be done?
Presumably one could also show something on the user's repo listing page, i.e. a run-button-per-project. Quick snapshot of a user's reproducibility!

### What's it look like?
No big surprise. If there's a better icon, or we actually want to use the binder logo, that's great.

<img width="1440" alt="screen shot 2016-03-18 at 12 26 36 am" src="https://cloud.githubusercontent.com/assets/45380/13868519/280264b6-eca0-11e5-89a0-3ede069cd1bc.png">

<img width="1440" alt="screen shot 2016-03-18 at 12 28 01 am" src="https://cloud.githubusercontent.com/assets/45380/13868529/4b463c0e-eca0-11e5-9b8e-8ab9ec9dc6e6.png">

Hooray!
