### PR TITLE
Add nbviewer CSS class to body tag

### DIFF
--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -70,7 +70,7 @@
   {% block extra_head %}{% endblock %}
 </head>
 
-<body>
+<body class="nbviewer">
 
   <!-- These are loaded at the top of the body so they are available to
        notebook cells when they are loaded below. -->


### PR DESCRIPTION
Help JS in a notebook know that it is executing on nbviewer. Makes it possible for notebooks to embed scripts meant only for nbviewer (e.g., https://gist.github.com/parente/4c3e6936d0d7a46fd071)