### PR TITLE
relax gist hash length regex

### DIFF
--- a/nbviewer/providers/gist/handlers.py
+++ b/nbviewer/providers/gist/handlers.py
@@ -186,10 +186,10 @@ def default_handlers(handlers=[]):
     """Tornado handlers"""
 
     return handlers + [
-        (r'/gist/([^\/]+/)?([0-9]+|[0-9a-f]{20})', GistHandler),
-        (r'/gist/([^\/]+/)?([0-9]+|[0-9a-f]{20})/(?:files/)?(.*)', GistHandler),
-        (r'/([0-9]+|[0-9a-f]{20})', GistRedirectHandler),
-        (r'/([0-9]+|[0-9a-f]{20})/(.*)', GistRedirectHandler),
+        (r'/gist/([^\/]+/)?([0-9]+|[0-9a-f]{20,})', GistHandler),
+        (r'/gist/([^\/]+/)?([0-9]+|[0-9a-f]{20,})/(?:files/)?(.*)', GistHandler),
+        (r'/([0-9]+|[0-9a-f]{20,})', GistRedirectHandler),
+        (r'/([0-9]+|[0-9a-f]{20,})/(.*)', GistRedirectHandler),
         (r'/gist/([^\/]+)/?', UserGistsHandler),
     ]
 


### PR DESCRIPTION
Allow >= 20 characters, rather than strictly 20 because gist IDs are now 32 characters, and there's no reason to be strict about it that I can see.