### PR TITLE
updating to invoke 0.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ install:
 - pip install -r requirements.txt
 - invoke bower
 - invoke less
-script: invoke test
+script:
+  - invoke test
+  - docker-compose build
 env:
   global:
   - secure: Sv53YMdsVTin1hUPRqIuvdAOJ0UwklEowW49qpxY9wSgiAM79D+e1b5Yxrn+RTtS3WGlvK1aKHICc+2ajccEJkKFL8WDy2SnTnoWPadrEy4NAGLkNMGK+bAYMnLNoNRbSGVz5JpvNJ7JkeaEplhJ572OJOxa1X7ZF9165ZbOWng=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,28 @@
 language: python
+
 node_js:
 - '0.10'
+
 python:
 - '2.7'
 - '3.3'
 - '3.4'
+
 before_install:
 - sudo apt-get update
 - sudo apt-get install -qq libzmq3-dev pandoc libcurl4-gnutls-dev libmemcached-dev
 - pip install -U setuptools
 - pip install -r requirements-dev.txt
 - npm install .
+
 install:
 - pip install -r requirements.txt
 - invoke bower
 - invoke less
+
 script:
-  - invoke test
-  - docker-compose build
+- invoke test
+
 env:
   global:
   - secure: Sv53YMdsVTin1hUPRqIuvdAOJ0UwklEowW49qpxY9wSgiAM79D+e1b5Yxrn+RTtS3WGlvK1aKHICc+2ajccEJkKFL8WDy2SnTnoWPadrEy4NAGLkNMGK+bAYMnLNoNRbSGVz5JpvNJ7JkeaEplhJ572OJOxa1X7ZF9165ZbOWng=

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 coverage
-invoke
+invoke>=0.13.0
 mock>=1.3.0  # python34 and older versions of mock do not play well together.
 nose
 requests

--- a/tasks.py
+++ b/tasks.py
@@ -27,11 +27,11 @@ NOTEBOOK_STATIC_PATH = os.path.join(APP_ROOT, 'notebook-%s' % NOTEBOOK_VERSION, 
 
 
 @invoke.task
-def test():
+def test(ctx):
     invoke.run("nosetests -v")
 
 @invoke.task
-def bower():
+def bower(ctx):
     invoke.run(
         "cd {}/nbviewer/static &&".format(APP_ROOT) +
         " {}/bower install".format(NPM_BIN) +
@@ -40,7 +40,7 @@ def bower():
 
 
 @invoke.task
-def notebook_static():
+def notebook_static(ctx):
     if os.path.exists(NOTEBOOK_STATIC_PATH):
         return
     fname = 'notebook-%s.tar.gz' % NOTEBOOK_VERSION
@@ -60,8 +60,8 @@ def notebook_static():
 
 
 @invoke.task
-def less(debug=False):
-    notebook_static()
+def less(ctx, debug=False):
+    notebook_static(ctx)
     if debug:
         extra = "--source-map"
     else:
@@ -86,7 +86,7 @@ def less(debug=False):
 
 
 @invoke.task
-def screenshots(root="http://localhost:5000/", dest="./screenshots"):
+def screenshots(ctx, root="http://localhost:5000/", dest="./screenshots"):
     dest = os.path.abspath(dest)
 
     script = """
@@ -107,7 +107,7 @@ def screenshots(root="http://localhost:5000/", dest="./screenshots"):
             desktop_standard: [1280, 1024]
             desktop_1080p: [1920, 1080]
         }})
-        
+
         casper.start root
 
         casper.each screens, (_, screen) ->
@@ -122,11 +122,11 @@ def screenshots(root="http://localhost:5000/", dest="./screenshots"):
 
         casper.run()
     """.format(root=root, dest=dest)
-    
+
     tmpdir = tempfile.mkdtemp()
     tmpfile = os.path.join(tmpdir, "screenshots.coffee")
     with open(tmpfile, "w+") as f:
         f.write(script)
     invoke.run("casperjs test {script}".format(script=tmpfile))
-    
+
     shutil.rmtree(tmpdir)

--- a/tasks.py
+++ b/tasks.py
@@ -28,11 +28,11 @@ NOTEBOOK_STATIC_PATH = os.path.join(APP_ROOT, 'notebook-%s' % NOTEBOOK_VERSION, 
 
 @invoke.task
 def test(ctx):
-    invoke.run("nosetests -v")
+    ctx.run("nosetests -v")
 
 @invoke.task
 def bower(ctx):
-    invoke.run(
+    ctx.run(
         "cd {}/nbviewer/static &&".format(APP_ROOT) +
         " {}/bower install".format(NPM_BIN) +
         " --config.interactive=false --allow-root"
@@ -56,7 +56,7 @@ def notebook_static(ctx):
         print("Expected: %s" % NOTEBOOK_CHECKSUM, file=sys.stderr)
         print("Got: %s" % checksum, file=sys.stderr)
         sys.exit(1)
-    invoke.run("tar -xzf '{}'".format(nb_tgz))
+    ctx.run("tar -xzf '{}'".format(nb_tgz))
 
 
 @invoke.task
@@ -80,7 +80,7 @@ def less(ctx, debug=False):
     args = (extra, NOTEBOOK_STATIC_PATH)
 
     [
-        invoke.run(tmpl.format(less_file, *args))
+        ctx.run(tmpl.format(less_file, *args))
         for less_file in ["styles", "notebook", "slides"]
     ]
 
@@ -127,6 +127,6 @@ def screenshots(ctx, root="http://localhost:5000/", dest="./screenshots"):
     tmpfile = os.path.join(tmpdir, "screenshots.coffee")
     with open(tmpfile, "w+") as f:
         f.write(script)
-    invoke.run("casperjs test {script}".format(script=tmpfile))
+    ctx.run("casperjs test {script}".format(script=tmpfile))
 
     shutil.rmtree(tmpdir)


### PR DESCRIPTION
Thanks to @ChristianKniep on #616, looks like `invoke` changed its API since last we tried to build stuff. This breaks the docker image, and of course local installation.

This is a quick fix, adding the `ctx` argument to each of the tasks, which is now the preferred way to call other tasks: i.e. `ctx.run` vs `invoke.run`.

Since travis has raised it's game significantly with respect to docker, I'm adding an explicit test of our docker stuff there to assist in testing against docker for future work. Another approach would be to have the dockerfile itself run the tests... really just a oneliner.