### PR TITLE
Add directory support to --localfiles

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -235,7 +235,7 @@ def make_app():
     if options.localfiles:
         log.app_log.warning("Serving local notebooks in %s, this can be a security risk", options.localfiles)
         # use absolute or relative paths:
-        local_handlers = [( url_path_join(options.base_url, r'/localfile/(.*)'), LocalFileHandler)]
+        local_handlers = [( url_path_join(options.base_url, r'/localfile/?(.*)'), LocalFileHandler)]
         handlers = (
             local_handlers +
             format_handlers(formats, local_handlers) +

--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -199,10 +199,10 @@ class BaseHandler(web.RequestHandler):
             return breadcrumbs
 
         for name in path.split('/'):
-            href = base_url = url_path_join(base_url, name)
+            base_url = url_path_join(base_url, name)
             breadcrumbs.append({
-                'url' : base_url,
-                'name' : name,
+                'url': base_url,
+                'name': name,
             })
         return breadcrumbs
 

--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -5,6 +5,7 @@
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 
+import errno
 import io
 import os
 
@@ -14,6 +15,7 @@ from tornado import (
 )
 from tornado.log import app_log
 
+from ...utils import url_path_join
 from ..base import (
     cached,
     RenderingHandler,
@@ -25,32 +27,109 @@ class LocalFileHandler(RenderingHandler):
 
     Serving notebooks from the local filesystem
     """
+    @property
+    def localfile_path(self):
+        return os.path.abspath(self.settings.get('localfile_path', ''))
+
     @cached
     @gen.coroutine
     def get(self, path):
-
-        localfile_path = os.path.abspath(
-            self.settings.get('localfile_path', ''))
-
         abspath = os.path.abspath(os.path.join(
-            localfile_path,
+            self.localfile_path,
             path
         ))
 
-        app_log.info("looking for file: '%s'" % abspath)
-
-        if not abspath.startswith(localfile_path):
-            app_log.warn("directory traversal attempt: '%s'" % localfile_path)
+        if not abspath.startswith(self.localfile_path):
+            app_log.warn("directory traversal attempt: '%s'" %
+                         self.localfile_path)
             raise web.HTTPError(404)
 
         if not os.path.exists(abspath):
             raise web.HTTPError(404)
 
-        with io.open(abspath, encoding='utf-8') as f:
-            nbdata = f.read()
+        if os.path.isdir(abspath):
+            html = self.show_dir(abspath, path)
+            raise gen.Return(self.cache_and_finish(html))
+
+        try:
+            with io.open(abspath, encoding='utf-8') as f:
+                nbdata = f.read()
+        except IOError as ex:
+            if ex.errno == errno.EACCES:
+                # py2/3: can't read the file, so don't give away it exists
+                raise web.HTTPError(404)
+            raise ex
 
         yield self.finish_notebook(nbdata, download_url=path,
                                    msg="file from localfile: %s" % path,
                                    public=False,
                                    format=self.format,
                                    request=self.request)
+
+    def show_dir(self,  abspath,  path):
+        """Render the directory view template for a given filesystem path.
+
+        Parameters
+        ==========
+        abspath: string
+            Absolute path on disk to show
+        path: string
+            URL path equating to the path on disk
+
+        Returns
+        =======
+        str
+            Rendered HTML
+        """
+        base_url = '/localfile'
+
+        breadcrumbs = [{
+            'url': url_path_join(self.base_url, base_url),
+            'name': 'home'
+        }]
+        breadcrumbs.extend(self.breadcrumbs(path, base_url))
+
+        entries = []
+        dirs = []
+        ipynbs = []
+
+        try:
+            contents = os.listdir(abspath)
+        except IOError as ex:
+            if ex.errno == errno.EACCES:
+                # py2/3: can't access the dir, so don't give away its presence
+                raise web.HTTPError(404)
+
+        for f in contents:
+            absf = os.path.join(abspath, f)
+            entry = {}
+            entry['name'] = f
+
+            # skip hidden or "hidden" files
+            if f.startswith('.') or f.startswith('_'):
+                continue
+            elif os.path.isdir(absf):
+                if not os.access(absf, os.X_OK | os.R_OK):
+                    # skip directories we cannot visit
+                    continue
+                entry['url'] = url_path_join(base_url, path, f)
+                entry['class'] = 'fa fa-folder-open'
+                dirs.append(entry)
+            elif f.endswith('.ipynb'):
+                if not os.access(absf, os.R_OK):
+                    # skip files we cannot read
+                    continue
+                entry['url'] = url_path_join(base_url, path, f)
+                entry['class'] = 'fa fa-book'
+                ipynbs.append(entry)
+
+        dirs.sort(key=lambda e: e['name'])
+        ipynbs.sort(key=lambda e: e['name'])
+
+        entries.extend(dirs)
+        entries.extend(ipynbs)
+
+        html = self.render_template('dirview.html',
+                                    entries=entries,
+                                    breadcrumbs=breadcrumbs)
+        return html

--- a/nbviewer/templates/dirview.html
+++ b/nbviewer/templates/dirview.html
@@ -1,0 +1,29 @@
+{% extends "layout.html" %}
+{% block body %}
+{{ link_breadcrumbs(breadcrumbs) }}
+<table class='table table-condensed table-bordered table-striped'>
+  <thead>
+    <tr><th>Name</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        {% if len(breadcrumbs) > 1 %}
+          <a href='{{ from_base(breadcrumbs[-2]["url"]) }}'><i class='fa fa-level-up'></i> ..</a>
+        {% endif %}
+      </td>
+    </tr>
+    {% for entry in entries %}
+      <tr><td><i class='{{entry.class}}'></i>
+        {% if entry.url %}
+          <a href='{{ from_base(entry.url) }}'>
+        {% endif %}
+        {{entry.name}}
+        {% if entry.url %}
+          </a>
+        {% endif %}
+      </td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
Allows navigation of directories under the localfiles root. Renders them in a page layout similar to the treelist template.