### PR TITLE
Fix localfile + base url + format support

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -42,7 +42,6 @@ from .index import NoSearch, ElasticSearch
 from .formats import configure_formats
 
 from .providers import default_providers, default_rewrites
-from .providers.local import LocalFileHandler
 
 try:
     from .providers.url.client import NBViewerCurlAsyncHTTPClient as HTTPClientClass
@@ -238,18 +237,11 @@ def make_app():
         hub_base_url=os.getenv('JUPYTERHUB_BASE_URL'),
     )
 
-    # handle handlers
-    handlers = init_handlers(formats, options.providers, base_url)
-
     if options.localfiles:
         log.app_log.warning("Serving local notebooks in %s, this can be a security risk", options.localfiles)
-        # use absolute or relative paths:
-        local_handlers = [( url_path_join(base_url, r'/localfile/?(.*)'), LocalFileHandler)]
-        handlers = (
-            local_handlers +
-            format_handlers(formats, local_handlers) +
-            handlers
-        )
+
+    # handle handlers
+    handlers = init_handlers(formats, options.providers, base_url, options.localfiles)
 
     # create the app
     return web.Application(handlers, debug=options.debug, **settings)

--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -17,6 +17,7 @@ from .providers.base import (
     BaseHandler,
     format_prefix,
 )
+from .providers.local import LocalFileHandler
 
 #-----------------------------------------------------------------------------
 # Handler classes
@@ -81,7 +82,7 @@ def format_handlers(formats, handlers):
     ]
 
 
-def init_handlers(formats, providers, base_url):
+def init_handlers(formats, providers, base_url, localfiles):
     pre_providers = [
         ('/', IndexHandler),
         ('/index.html', IndexHandler),
@@ -97,6 +98,9 @@ def init_handlers(formats, providers, base_url):
     ]
 
     handlers = provider_handlers(providers)
+
+    # Add localfile handlers if the option is set
+    handlers = [(r'/localfile/?(.*)', LocalFileHandler)]+handlers if localfiles else handlers
 
     raw_handlers = (
         pre_providers +


### PR DESCRIPTION
Need to prefix localfile format handlers with the base url too. Move the
code that adds the localfile handlers to the handlers modules so we can
take one prefixing pass through all the handlers, instead of worrying
about what is already prefixed vs not.