### PR TITLE
Add jupyter-js-widgets embedder

### DIFF
--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -157,6 +157,7 @@
     </footer>
   {% endblock footer %}
 
+  <script src="https://unpkg.com/jupyter-js-widgets@2.0.*/dist/embed.js"></script>
   <script src="{{ static_url("components/bootstrap/js/bootstrap.min.js") }}"></script>
   <script src="{{ static_url("components/headroom.js/dist/headroom.min.js") }}"></script>
   <script src="{{ static_url("components/headroom.js/dist/jQuery.headroom.min.js") }}"></script>


### PR DESCRIPTION
This will complete inline rendering in nbconvert once https://github.com/jupyter/nbconvert/pull/482 gets in a release.

Ping @michaelpacer 