### PR TITLE
tweak debug and info-level log content

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -291,6 +291,16 @@ def init_options():
 def main(argv=None):
     init_options()
     tornado.options.parse_command_line(argv)
+    
+    try:
+        from tornado.curl_httpclient import curl_log
+    except ImportError as e:
+        log.app_log.warning("Failed to import curl: %s", e)
+    else:
+        # debug-level curl_log logs all headers, info for upstream requests,
+        # which is just too much.
+        curl_log.setLevel(max(log.app_log.getEffectiveLevel(), logging.INFO))
+    
 
     # create and start the app
     app = make_app()

--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -524,7 +524,7 @@ def cached(method):
             cached = None
 
         if cached is not None:
-            app_log.debug("cache hit %s", short_url)
+            app_log.info("cache hit %s", short_url)
             for key, value in cached['headers'].items():
                 self.set_header(key, value)
             self.write(cached['body'])
@@ -617,8 +617,8 @@ class RenderingHandler(BaseHandler):
 
         try:
             app_log.debug("Requesting render of %s", download_url)
-            with time_block("Rendered %s" % download_url):
-                app_log.info("rendering %d B notebook from %s", len(json_notebook), download_url)
+            with time_block("Rendered %s" % download_url, debug_limit=0):
+                app_log.info("Rendering %d B notebook from %s", len(json_notebook), download_url)
                 render_time = self.statsd.timer('rendering.nbrender.time').start()
                 nbhtml, config = yield self.pool.submit(render_notebook,
                     self.formats[format], nb, download_url,

--- a/nbviewer/providers/github/client.py
+++ b/nbviewer/providers/github/client.py
@@ -90,7 +90,7 @@ class AsyncGitHubClient(object):
             return
         
         if 10 * remaining > limit:
-            log = app_log.debug
+            log = app_log.info
         else:
             log = app_log.warn
         log("%i/%i GitHub API requests remaining", remaining, limit)

--- a/nbviewer/providers/url/client.py
+++ b/nbviewer/providers/url/client.py
@@ -66,7 +66,7 @@ class NBViewerAsyncHTTPClient(object):
             cached_response = yield self._get_cached_response(cache_key, name)
         
         if cached_response:
-            app_log.debug("Upstream cache hit %s", name)
+            app_log.info("Upstream cache hit %s", name)
             # add cache headers, if any
             for resp_key, req_key in cache_headers.items():
                 value = cached_response.headers.get(resp_key)
@@ -84,7 +84,7 @@ class NBViewerAsyncHTTPClient(object):
             callback(response)
         else:
             if not response.error:
-                log("Fetched  %s in %.2f ms", name, 1e3 * dt)
+                app_log.info("Fetched  %s in %.2f ms", name, 1e3 * dt)
             callback(response)
             if not response.error:
                 yield self._cache_response(cache_key, name, response)

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -245,13 +245,17 @@ def base64_encode(s):
 
 
 @contextmanager
-def time_block(message):
+def time_block(message, debug_limit=1):
     """context manager for timing a block
 
     logs millisecond timings of the block
+    
+    If the time is longer than debug_limit,
+    then log level will be INFO,
+    otherwise it will be DEBUG.
     """
     tic = time.time()
     yield
     dt = time.time() - tic
-    log = app_log.info if dt > 1 else app_log.debug
+    log = app_log.info if dt > debug_limit else app_log.debug
     log("%s in %.2f ms", message, 1e3 * dt)


### PR DESCRIPTION
- limit curl logging to INFO even when the rest of the app is debug-level because it logs way too much.
- promote some timings, cache hits, API rate limits to INFO