### PR TITLE
Increase upstream response caching

### DIFF
--- a/nbviewer/providers/github/client.py
+++ b/nbviewer/providers/github/client.py
@@ -83,7 +83,7 @@ class AsyncGitHubClient(object):
         
         remaining = int(remaining_s)
         limit = int(limit_s)
-        if remaining == 0:
+        if remaining == 0 and r.code >= 400:
             text = response_text(r)
             try:
                 message = json.loads(text)['message']

--- a/nbviewer/providers/url/client.py
+++ b/nbviewer/providers/url/client.py
@@ -72,6 +72,11 @@ class NBViewerAsyncHTTPClient(object):
         
         if cached_response:
             app_log.info("Upstream cache hit %s", name)
+            user_agent = request.headers.get('User-Agent', 'bot')
+            if 'bot' in user_agent.lower():
+                app_log.info('Using cached response for bot="%s"', user_agent)
+                callback(cached_response)
+                return
             # add cache headers, if any
             for resp_key, req_key in cache_headers.items():
                 value = cached_response.headers.get(resp_key)

--- a/nbviewer/providers/url/client.py
+++ b/nbviewer/providers/url/client.py
@@ -46,7 +46,10 @@ class NBViewerAsyncHTTPClient(object):
     """
     
     cache = None
-    expiry = 7200
+    # Cache upstream responses for one week
+    # we still send a follow-up request to check 304,
+    # so the only cost of a high value here is cache size.
+    expiry = 3600 * 24 * 7
     
     def fetch_impl(self, request, callback):
         self.io_loop.add_callback(lambda : self._fetch_impl(request, callback))

--- a/nbviewer/providers/url/client.py
+++ b/nbviewer/providers/url/client.py
@@ -42,7 +42,10 @@ class NBViewerAsyncHTTPClient(object):
     Upstream requests are still made every time,
     but resources and rate limits may be saved by 304 responses.
     
-    Currently, responses are cached for a non-configurable two hours.
+    If upstream responds with 304 or an error and a cached response is available,
+    use the cached response.
+    
+    Responses are cached as long as possible.
     """
     
     cache = None
@@ -66,11 +69,6 @@ class NBViewerAsyncHTTPClient(object):
         
         if cached_response:
             app_log.info("Upstream cache hit %s", name)
-            user_agent = request.headers.get('User-Agent', 'bot')
-            if 'bot' in user_agent.lower():
-                app_log.info('Using cached response for bot="%s"', user_agent)
-                callback(cached_response)
-                return
             # add cache headers, if any
             for resp_key, req_key in cache_headers.items():
                 value = cached_response.headers.get(resp_key)


### PR DESCRIPTION
- Stop expiring cache of upstream responses. Since we still make a follow-up request, there is no cost in caching these as long as possible. Memcache will cleanup the oldest entries if it starts to fill up.
- When the follow-up request fails, re-use the cached response instead of failing.
- <del>Reduce load impact of bots on load by always using a cached response if there is one.</del> saving this for a later PR, since it's not as simple as I thought to tell what incoming request an outgoing request is on behalf of.