### PR TITLE
Implement rate limiting

### DIFF
--- a/nbviewer/cache.py
+++ b/nbviewer/cache.py
@@ -170,9 +170,11 @@ class AsyncMultipartMemcache(AsyncMemcache):
         if parts:
             compressed = b''.join(parts)
             try:
-                return zlib.decompress(compressed)
+                result = zlib.decompress(compressed)
             except zlib.error as e:
                 app_log.error("zlib decompression of %s failed: %s", key, e)
+            else:
+                raise gen.Return(result)
     
     @gen.coroutine
     def set(self, key, value, *args, **kwargs):

--- a/nbviewer/cache.py
+++ b/nbviewer/cache.py
@@ -5,15 +5,16 @@
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 
-import os
 import zlib
+try:
+    from time import monotonic
+except ImportError:
+    from time import time as monotonic
 
 from concurrent.futures import ThreadPoolExecutor
 from tornado.concurrent import Future
 
 from tornado import gen
-from tornado.httpclient import AsyncHTTPClient
-from tornado.httputil import url_concat
 from tornado.log import app_log
 
 try:
@@ -40,19 +41,37 @@ class MockCache(object):
         f.set_result(None)
         return f
 
+    def add(self, key, value, *args, **kwargs):
+        f = Future()
+        f.set_result(True)
+        return f
+
+    def incr(self, key):
+        f = Future()
+        f.set_result(None)
+        return f
+
 class DummyAsyncCache(object):
     """Dummy Async Cache. Just stores things in a dict of fixed size."""
     def __init__(self, limit=10):
         self._cache = {}
         self._cache_order = []
         self.limit = limit
-    
+
     def get(self, key):
         f = Future()
-        f.set_result(self._cache.get(key))
+        f.set_result(self._get(key))
         return f
 
-    def set(self, key, value, time=0):
+    def _get(self, key):
+        value, deadline = self._cache.get(key, (None, None))
+        if deadline and deadline < monotonic():
+            self._cache.pop(key)
+            self._cache_order.remove(key)
+        else:
+            return value
+
+    def set(self, key, value, expires=0):
         if key in self._cache and self._cache_order[-1] != key:
             idx = self._cache_order.index(key)
             del self._cache_order[idx]
@@ -62,9 +81,35 @@ class DummyAsyncCache(object):
                 oldest = self._cache_order.pop(0)
                 self._cache.pop(oldest)
             self._cache_order.append(key)
-        self._cache[key] = value
+
+        if not expires:
+            deadline = None
+        else:
+            deadline = monotonic() + expires
+
+        self._cache[key] = (value, deadline)
         f = Future()
-        f.set_result(None)
+        f.set_result(True)
+        return f
+    
+    def add(self, key, value, expires=0):
+        f = Future()
+        if self._get(key) is not None:
+            f.set_result(False)
+        else:
+            self.set(key, value, expires)
+            f.set_result(True)
+        return f
+
+    def incr(self, key):
+        f = Future()
+        if self._get(key) is not None:
+            value, deadline = self._cache[key]
+            value = value + 1
+            self._cache[key] = (value, deadline)
+        else:
+            value = None
+        f.set_result(value)
         return f
 
 class AsyncMemcache(object):
@@ -78,23 +123,29 @@ class AsyncMemcache(object):
         self.mc = pylibmc.Client(*args, **kwargs)
         self.mc_pool = pylibmc.ThreadMappedPool(self.mc)
     
-    def get(self, key, *args, **kwargs):
-        app_log.debug("memcache get submit %s", key)
-        return self.pool.submit(self._threadsafe_get, key, *args, **kwargs)
+    def _call_in_thread(self, method_name, *args, **kwargs):
+        key = args[0]
+        if 'multi' in method_name:
+            key = sorted(key)[0].decode('ascii') + '[%i]' % len(key)
+        app_log.debug("memcache submit %s %s", method_name, key)
+        def f():
+            app_log.debug("memcache %s %s", method_name, key)
+            with self.mc_pool.reserve() as mc:
+                meth = getattr(mc, method_name)
+                return meth(*args, **kwargs)
+        return self.pool.submit(f)
     
-    def _threadsafe_get(self, key, *args, **kwargs):
-        app_log.debug("memcache get %s", key)
-        with self.mc_pool.reserve() as mc:
-            return mc.get(key, *args, **kwargs)
+    def get(self, *args, **kwargs):
+        return self._call_in_thread('get', *args, **kwargs)
     
-    def set(self, key, *args, **kwargs):
-        app_log.debug("memcache set submit %s", key)
-        return self.pool.submit(self._threadsafe_set, key, *args, **kwargs)
-
-    def _threadsafe_set(self, key, value, *args, **kwargs):
-        app_log.debug("memcache set %s", key)
-        with self.mc_pool.reserve() as mc:
-            return mc.set(key, value, *args, **kwargs)
+    def set(self, *args, **kwargs):
+        return self._call_in_thread('set', *args, **kwargs)
+    
+    def add(self, *args, **kwargs):
+        return self._call_in_thread('add', *args, **kwargs)
+    
+    def incr(self, *args, **kwargs):
+        return self._call_in_thread('incr', *args, **kwargs)
 
 class AsyncMultipartMemcache(AsyncMemcache):
     """subclass of AsyncMemcache that splits large files into multiple chunks
@@ -106,12 +157,11 @@ class AsyncMultipartMemcache(AsyncMemcache):
         self.max_chunks = kwargs.pop('max_chunks', 16)
         super(AsyncMultipartMemcache, self).__init__(*args, **kwargs)
     
-    def _threadsafe_get(self, key, *args, **kwargs):
-        app_log.debug("memcache get %s", key)
+    @gen.coroutine
+    def get(self, key, *args, **kwargs):
         keys = [('%s.%i' % (key, idx)).encode()
                 for idx in range(self.max_chunks)]
-        with self.mc_pool.reserve() as mc:
-            values = mc.get_multi(keys, *args, **kwargs)
+        values = yield self._call_in_thread('get_multi', keys, *args, **kwargs)
         parts = []
         for key in keys:
             if key not in values:
@@ -124,8 +174,8 @@ class AsyncMultipartMemcache(AsyncMemcache):
             except zlib.error as e:
                 app_log.error("zlib decompression of %s failed: %s", key, e)
     
-    def _threadsafe_set(self, key, value, *args, **kwargs):
-        app_log.debug("memcache set %s", key)
+    @gen.coroutine
+    def set(self, key, value, *args, **kwargs):
         chunk_size = self.chunk_size
         compressed = zlib.compress(value)
         offsets = range(0, len(compressed), chunk_size)
@@ -137,6 +187,5 @@ class AsyncMultipartMemcache(AsyncMemcache):
             values[('%s.%i' % (key, idx)).encode()] = compressed[
                 offset:offset + chunk_size
             ]
-        with self.mc_pool.reserve() as mc:
-            return mc.set_multi(values, *args, **kwargs)
+        return self._call_in_thread('set_multi', values, *args, **kwargs)
 

--- a/nbviewer/ratelimit.py
+++ b/nbviewer/ratelimit.py
@@ -1,0 +1,62 @@
+"""Object for tracking rate-limited requests"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import hashlib
+
+from tornado.gen import coroutine
+from tornado.log import app_log
+from tornado.web import HTTPError
+
+class RateLimiter(object):
+    """Rate limit checking object"""
+    def __init__(self, limit, interval, cache):
+        self.limit = limit
+        self.interval = interval
+        self.cache = cache
+    
+    def key_for_handler(self, handler):
+        """Identify a visitor.
+        
+        Currently combine ip + user-agent.
+        We don't need to be perfect.
+        """
+        agent = handler.request.headers.get('User-Agent', '')
+        return 'rate-limit:{}:{}'.format(
+            handler.request.remote_ip,
+            hashlib.md5(agent.encode('utf8', 'replace')).hexdigest(),
+        )
+    
+    @coroutine
+    def check(self, handler):
+        """Check the rate limit for a handler.
+        
+        Identifies the source by ip and user-agent.
+        
+        If the rate limit is exceeded, raise HTTPError(429)
+        """
+        if not self.limit:
+            return
+        key = self.key_for_handler(handler)
+        added = yield self.cache.add(key, 1, self.interval)
+        if not added:
+            # it's been seen before, use incr
+            try:
+                count = yield self.cache.incr(key)
+            except Exception as e:
+                app_log.warning("Failed to increment rate limit for %s", key)
+                return
+
+            app_log.debug("Rate limit remaining for %r: %s/%s", key, self.limit - count, self.limit)
+
+            if count and count >= self.limit:
+                minutes = self.interval // 60
+                raise HTTPError(429,
+                    "Rate limit exceeded for {ip} ({limit} req / {minutes} min)."
+                    " Try again later.".format(
+                        ip=handler.request.remote_ip,
+                        limit=self.limit,
+                        minutes=minutes,
+                    )
+                )


### PR DESCRIPTION
Recent usage is caused by crawlers triggering a bunch of renders. Most traffic has in fact been bots recently. Implementing a light rate limit should keep them from exhausting our GitHub API limit too easily.

Use memcache expiry for rate limiting. If cache dumps keys, rate limit might not be enforced, but that's not a huge deal.

default rate limit: 60 reqs / 10 minutes

Rate limit key is ip + user-agent. A bunch of users behind a router with the same browser will share a rate limit, but this shouldn't be a big issue. If they are visiting the same pages, they won't be bumping up the rate limit much because shared destinations will be in the cache.

Rate limit only applies to requests that would cost some work:

1. method is cached (most renderers, etc.), and
2. result is not *in* the cache, so it needs to be computed.

cc @rgbkrk