### PR TITLE
Add "Show/Hide Inputs" button to navbar

### DIFF
--- a/nbviewer/static/less/notebook.less
+++ b/nbviewer/static/less/notebook.less
@@ -11,7 +11,6 @@
   text-align: center;
 }
 
-
 @media (max-width: 767px) {
   div.input, div.output_area {
     box-orient: vertical;
@@ -20,8 +19,60 @@
   div.prompt {
     text-align:left;
   }
-  
+
   .cell img {
     .img-responsive;
   }
+}
+
+/* Show/hide cell inputs, largely from @mpacer's
+ * https://github.com/mpacer/hiding_tags_nbconvert/blob/f37b7/toggle_hidden.tpl
+ */
+:root {
+    --in-time: .5s;
+    --out-time: .5s;
+    --max-height-small: 0px;
+    --max-height-big: 10000px;
+    --transition-path-out: cubic-bezier(0, 0.67, 0.36, 1);
+    --transition-path-in: ease-in-out;
+    --padding-hidden: 0px;
+    --padding-shown: 10px;
+}
+
+/* Adjust vertical padding on all but the first cell */
+body div.cell ~ div.cell {
+    transition: padding-top var(--in-time) var(--transition-path-in), padding-bottom var(--in-time) var(--transition-path-in);
+    -webkit-transition: padding-top var(--in-time) var(--transition-path-in), padding-bottom var(--in-time) var(--transition-path-in);
+    -moz-transition: padding-top var(--in-time) var(--transition-path-in), padding-bottom var(--in-time) var(--transition-path-in);
+    -o-transition: padding-top var(--in-time) var(--transition-path-in), padding-bottom var(--in-time) var(--transition-path-in);
+    padding-top: var(--padding-shown);
+    padding-bottom: var(--padding-shown);
+}
+
+body.hide_input_cells div.cell ~ div.cell {
+    transition: padding-top var(--in-time) var(--transition-path-out), padding-bottom var(--in-time) var(--transition-path-out);
+    -webkit-transition: padding-top var(--in-time) var(--transition-path-out), padding-bottom var(--in-time) var(--transition-path-out);
+    -moz-transition: padding-top var(--in-time) var(--transition-path-out), padding-bottom var(--in-time) var(--transition-path-out);
+    -o-transition: padding-top var(--in-time) var(--transition-path-out), padding-bottom var(--in-time) var(--transition-path-out);
+    padding-top: var(--padding-hidden);
+    padding-bottom: var(--padding-hidden);
+}
+
+/* adjust the max-height of input cells */
+body div.input {
+    transition: max-height var(--in-time) var(--transition-path-in), padding .0s step-end;
+    -webkit-transition: max-height var(--in-time) var(--transition-path-in), padding .0s step-end;
+    -moz-transition: max-height var(--in-time) var(--transition-path-in), padding .0s step-end;
+    -o-transition: max-height var(--in-time) var(--transition-path-in), padding .0s step-end;
+    max-height: var(--max-height-big);
+}
+
+body.hide_input_cells div.input {
+    overflow:hidden;
+    max-height: var(--max-height-small);
+    transition: max-height var(--out-time) var(--transition-path-out), padding var(--out-time) step-end;
+    -webkit-transition: max-height var(--out-time) var(--transition-path-out), padding var(--out-time) step-end;
+    -moz-transition: max-height var(--out-time) var(--transition-path-out), padding var(--out-time) step-end;
+    -o-transition: max-height var(--out-time) var(--transition-path-out), padding var(--out-time) step-end;
+    padding: var(--padding-hidden);
 }

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -19,6 +19,16 @@
 {%- endmacro %}
 
 
+{% macro head_js_icon(js, name, icon, accesskey=None) -%}
+  <li>
+    <a href="javascript:{{js}}" title="{{name}}" {%if accesskey %}accesskey={{accesskey}}{% endif %}>
+      <span class="fa fa-{{icon}} fa-2x menu-icon"></span>
+      <span class="menu-text">{{name}}</span>
+    </a>
+  </li>
+{%- endmacro %}
+
+
 {% macro link_breadcrumbs(crumbs) -%}
   {% if crumbs %}
   <ol class="breadcrumb">

--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -2,17 +2,18 @@
 
 {% import "layout.html" as layout with context %}
 
-
 {% block otherlinks %}
   {% for fmt_name, fmt in formats.items() %}
     {% if format != fmt_name %}
       {% if fmt_name == default_format %}
         {{ layout.head_icon(from_base(format_base), "View as " ~ fmt.label, fmt.icon) }}
-      {% else %}
+     {% else %}
         {{ layout.head_icon(from_base(format_prefix, fmt_name, format_base), "View as " ~ fmt.label, fmt.icon) }}
       {% endif %}
     {% endif %}
   {% endfor %}
+
+  {{ layout.head_js_icon("toggle_nbviewer_inputs()", "Show/Hide Inputs", "eye", "i") }}
 
   {% if "kernelspec" in nb.metadata %}
     {{ layout.head_icon("#", nb.metadata.kernelspec.display_name + " Kernel", "server") }}
@@ -105,6 +106,43 @@
         unpinned: "slideOutUp"
       }
     })});
+  </script>
+
+  <script>
+    $(function(){
+      var code_shown = true;
+
+      function onShow() {
+        $('div.input').show(100, function() {
+          $('div.cell ~ div.cell').css({
+            'padding-top': '',
+            'padding-bottom': '',
+            'border-top': '',
+            'border-bottom': ''
+          });
+        });
+      }
+
+      function onHide() {
+        $('div.input').hide(100, function() {
+          // Remove vertical padding and border from all but the
+          // first cell to avoid large gaps of whitespace when
+          // code is hidden. Query is similar to :not(:first-child)
+          // but works on IE7+.
+          $('div.cell ~ div.cell').css({
+            'padding-top': 0,
+            'padding-bottom': 0,
+            'border-top': 0,
+            'border-bottom': 0
+          });
+        });
+      }
+
+      window.toggle_nbviewer_inputs = function() {
+        (code_shown) ? onHide() : onShow();
+        code_shown = !code_shown
+      }
+    });
   </script>
 {% endblock extra_script %}
 

--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -13,7 +13,7 @@
     {% endif %}
   {% endfor %}
 
-  {{ layout.head_js_icon("toggle_nbviewer_inputs()", "Show/Hide Inputs", "eye", "i") }}
+  {{ layout.head_js_icon("$('body').toggleClass('hide_input_cells');", "Show/Hide Inputs", "eye", "i") }}
 
   {% if "kernelspec" in nb.metadata %}
     {{ layout.head_icon("#", nb.metadata.kernelspec.display_name + " Kernel", "server") }}
@@ -106,43 +106,6 @@
         unpinned: "slideOutUp"
       }
     })});
-  </script>
-
-  <script>
-    $(function(){
-      var code_shown = true;
-
-      function onShow() {
-        $('div.input').show(100, function() {
-          $('div.cell ~ div.cell').css({
-            'padding-top': '',
-            'padding-bottom': '',
-            'border-top': '',
-            'border-bottom': ''
-          });
-        });
-      }
-
-      function onHide() {
-        $('div.input').hide(100, function() {
-          // Remove vertical padding and border from all but the
-          // first cell to avoid large gaps of whitespace when
-          // code is hidden. Query is similar to :not(:first-child)
-          // but works on IE7+.
-          $('div.cell ~ div.cell').css({
-            'padding-top': 0,
-            'padding-bottom': 0,
-            'border-top': 0,
-            'border-bottom': 0
-          });
-        });
-      }
-
-      window.toggle_nbviewer_inputs = function() {
-        (code_shown) ? onHide() : onShow();
-        code_shown = !code_shown
-      }
-    });
   </script>
 {% endblock extra_script %}
 

--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -7,7 +7,7 @@
     {% if format != fmt_name %}
       {% if fmt_name == default_format %}
         {{ layout.head_icon(from_base(format_base), "View as " ~ fmt.label, fmt.icon) }}
-     {% else %}
+      {% else %}
         {{ layout.head_icon(from_base(format_prefix, fmt_name, format_base), "View as " ~ fmt.label, fmt.icon) }}
       {% endif %}
     {% endif %}


### PR DESCRIPTION
Adds a button to toggle cell inputs to the navbar. Tries to collapse whitespace between visibly empty cells by removing padding and border while avoiding too much jitter and excessive animation. Super basic but very effective.

![toggle-inputs](https://cloud.githubusercontent.com/assets/153745/23678677/2598cefc-0353-11e7-956c-18f4b0bab918.gif)

The original idea is from @csaid (http://chris-said.io/2016/02/13/how-to-make-polished-jupyter-presentations-with-optional-code-visibility/). I tweaked it a bit in http://mindtrove.info/code-hiding-on-nbviewer/. Any reason this shouldn't live in nbviewer itself?