### PR TITLE
Add no-frontpage-input option to hide input form in nbviewer

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -228,6 +228,7 @@ def make_app():
         cache_expiry_max=options.cache_expiry_max,
         max_cache_uris=max_cache_uris,
         frontpage_sections=frontpage_sections,
+        no_frontpage_input=options.no_frontpage_input,
         pool=pool,
         gzip=True,
         render_timeout=options.render_timeout,
@@ -282,6 +283,7 @@ def init_options():
     define("threads", default=1, help="number of threads to use for rendering", type=int)
     define("processes", default=0, help="use processes instead of threads for rendering", type=int)
     define("frontpage", default=FRONTPAGE_JSON, help="path to json file containing frontpage content", type=str)
+    define("no_frontpage_input", default=False, help="Hide the frontpage input form (only show frontpage content)", type=bool)
     define("sslcert", help="path to ssl .crt file", type=str)
     define("sslkey", help="path to ssl .key file", type=str)
     define("no_check_certificate", default=False, help="Do not validate SSL certificates", type=bool)

--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -33,7 +33,10 @@ class Custom404(BaseHandler):
 class IndexHandler(BaseHandler):
     """Render the index"""
     def get(self):
-        self.finish(self.render_template('index.html', sections=self.frontpage_sections))
+        self.finish(self.render_template(
+            'index.html',
+            sections=self.frontpage_sections,
+            no_frontpage_input=self.no_frontpage_input))
 
 
 class FAQHandler(BaseHandler):

--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -186,6 +186,10 @@ class BaseHandler(web.RequestHandler):
         return self.settings.setdefault('frontpage_sections', {})
 
     @property
+    def no_frontpage_input(self):
+        return self.settings.setdefault('no_frontpage_input', False)
+
+    @property
     def mathjax_url(self):
         return self.settings['mathjax_url']
 

--- a/nbviewer/templates/index.html
+++ b/nbviewer/templates/index.html
@@ -4,6 +4,7 @@
   <header class="jumbotron masthead">
     <h1>nbviewer</h1>
     <p>A simple way to share Jupyter Notebooks</p>
+    {% if not no_frontpage_input %}
     <div class="row">
       <div class="col-md-10 col-md-offset-1">
         <form method="post" action="{{ from_base('/create/') }}">
@@ -23,6 +24,7 @@
         </form>
       </div>
     </div>
+    {% endif %} 
   </header>
 
   {% for section in sections %}

--- a/nbviewer/templates/index.html
+++ b/nbviewer/templates/index.html
@@ -1,10 +1,10 @@
 {% extends "layout.html" %}
 
 {% block body %}
+  {% if not no_frontpage_input %}
   <header class="jumbotron masthead">
     <h1>nbviewer</h1>
     <p>A simple way to share Jupyter Notebooks</p>
-    {% if not no_frontpage_input %}
     <div class="row">
       <div class="col-md-10 col-md-offset-1">
         <form method="post" action="{{ from_base('/create/') }}">
@@ -24,8 +24,8 @@
         </form>
       </div>
     </div>
-    {% endif %} 
   </header>
+  {% endif %} 
 
   {% for section in sections %}
     <section>


### PR DESCRIPTION
I wanted to be able to turn off the input form on nbviewer when using it within my organisation and just direct navigation through the featured content.