### PR TITLE
Add support for HTML iframes into nbviewer

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -105,11 +105,11 @@ def init_handlers(formats, providers, base_url, localfiles):
     handlers = provider_handlers(providers)
 
     # Add localfile handlers if the option is set
-    # handlers = [(r'/localfile/?(.*)', LocalFileHandler)]+handlers if localfiles else handlers
     if localfiles:
-        print('localfiles is: '+localfiles)
         pre_providers = pre_providers + [
-                (r'/localfile/?(.*\.html)', web.StaticFileHandler, {'path': os.path.abspath(localfiles)}),
+            # support for local *.html files (in iframes) passes through StaticFileHandler
+            (r'/localfile/?(.*\.html)', web.StaticFileHandler, {'path': os.path.abspath(localfiles)}),
+            # support for all other files passes through LocalFileHandler
             (r'/localfile/?(.*)', LocalFileHandler),
         ]
 

--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -4,6 +4,8 @@
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
+import os
+
 from tornado import web
 from tornado.log import app_log
 
@@ -103,7 +105,14 @@ def init_handlers(formats, providers, base_url, localfiles):
     handlers = provider_handlers(providers)
 
     # Add localfile handlers if the option is set
-    handlers = [(r'/localfile/?(.*)', LocalFileHandler)]+handlers if localfiles else handlers
+    # handlers = [(r'/localfile/?(.*)', LocalFileHandler)]+handlers if localfiles else handlers
+    if localfiles:
+        print('localfiles is: '+localfiles)
+        pre_providers = pre_providers + [
+                (r'/localfile/?(.*\.html)', web.StaticFileHandler, {'path': os.path.abspath(localfiles)}),
+            (r'/localfile/?(.*)', LocalFileHandler),
+        ]
+
 
     raw_handlers = (
         pre_providers +


### PR DESCRIPTION
I leverage nbviewer for internal sharing of data intel. I find the [interactive pivot table](http://nicolas.kruchten.com/content/2015/09/jupyter_pivottablejs/) an extremely useful add-on for my internal reports. This works well for local notebooks but causes 400 errors in nbviewer. 

Why? 

The [pivottable renderer writes a local html file](https://github.com/nicolaskruchten/jupyter_pivottablejs/blob/master/pivottablejs/__init__.py) containing the pivot table and then ports this to an iframe on the notebook. 

The [nbviewer LocalFileHandler](https://github.com/jupyter/nbviewer/blob/master/nbviewer/providers/local/handlers.py) expects all content to either by an ipython notebook or a downloadable attachment. Well the html file is local but it is neither a notebook nor a downloadable attachment.

The following patch works around this by adding support for local HTML files using the standard [StaticFileHandler](https://github.com/jupyter/nbviewer/blob/master/nbviewer/providers/local/handlers.py).
