### PR TITLE
Add default support for listing notebooks with non-english names in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM debian:jessie
 MAINTAINER Project Jupyter <jupyter@googlegroups.com>
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
 RUN apt-get update \
   && apt-get install -y -q \
     build-essential \


### PR DESCRIPTION
When trying to use docker for serving local notebooks with non-english names, by default it throws exception.

> [E 170524 20:58:22 concurrent:344] Future <tornado.concurrent.Future object at 0x7f2f96082b00> exception was never retrieved: Traceback (most recent call last):
      File "/usr/local/lib/python3.4/dist-packages/tornado/gen.py", line 307, in wrapper
        yielded = next(result)
      File "/srv/nbviewer/nbviewer/providers/base.py", line 474, in cache_and_finish
        self.write(content)
      File "/usr/local/lib/python3.4/dist-packages/tornado/web.py", line 717, in write
        chunk = utf8(chunk)
      File "/usr/local/lib/python3.4/dist-packages/tornado/escape.py", line 200, in utf8
        return value.encode("utf-8")
    UnicodeEncodeError: 'utf-8' codec can't encode character '\udce5' in position 5189: surrogates not allowed


A quick way to fix it by providing an environment flag when start the contain like the following.
`docker run -p 8080:8080 -e LANG=LANG=C.UTF-8  -v ~/notebooks/:/notebooks jupyter/nbviewer python3 -m nbviewer --port=8080  --localfiles=/notebooks`

However it's easier to just support it by default in Dockerfile.
