### PR TITLE
localfile navigation, naming improvements

### DIFF
--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -603,9 +603,10 @@ class RenderingHandler(BaseHandler):
                 app_log.info("failed to test %s: %s", self.request.uri, name)
 
     @gen.coroutine
-    def finish_notebook(self, json_notebook, download_url, provider_url=None, 
+    def finish_notebook(self, json_notebook, download_url, provider_url=None,
                         provider_icon=None, provider_label=None, msg=None,
-                        breadcrumbs=None, public=False, format=None, request=None):
+                        breadcrumbs=None, public=False, format=None, request=None,
+                        title=None):
         """render a notebook from its JSON body.
 
         download_url is required, provider_url is not.
@@ -663,6 +664,7 @@ class RenderingHandler(BaseHandler):
             format_base=self.request.uri.replace(self.format_prefix, "").replace(self.base_url, '/'),
             date=datetime.utcnow().strftime(date_fmt),
             breadcrumbs=breadcrumbs,
+            title=title,
             **config)
         html_time.stop()
 

--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -114,7 +114,8 @@ class LocalFileHandler(RenderingHandler):
                                    msg="file from localfile: %s" % path,
                                    public=False,
                                    format=self.format,
-                                   request=self.request)
+                                   request=self.request,
+                                   title=os.path.basename(path))
 
     def show_dir(self,  abspath,  path):
         """Render the directory view template for a given filesystem path.
@@ -187,5 +188,6 @@ class LocalFileHandler(RenderingHandler):
 
         html = self.render_template('dirview.html',
                                     entries=entries,
-                                    breadcrumbs=breadcrumbs)
+                                    breadcrumbs=breadcrumbs,
+                                    title=url_path_join(path, '/'))
         return html

--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -60,8 +60,9 @@ class LocalFileHandler(RenderingHandler):
         st = os.stat(abspath)
 
         self.set_header('Content-Length', st.st_size)
+        # Escape commas to workaround Chrome issue with commas in download filenames
         self.set_header('Content-Disposition',
-                        'attachment; filename={};'.format(filename))
+                        'attachment; filename={};'.format(filename.replace(',', '_')))
 
         content = web.StaticFileHandler.get_content(abspath)
         if isinstance(content, bytes):

--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -38,13 +38,27 @@ class LocalFileHandler(RenderingHandler):
     def localfile_path(self):
         return os.path.abspath(self.settings.get('localfile_path', ''))
 
-    def localfile_breadcrumbs(self, path):
+    def breadcrumbs(self, path):
+        """Build a list of breadcrumbs leading up to and including the
+        given local path.
+
+        Parameters
+        ----------
+        path: str
+            Relative path up to and including the leaf directory or file to include
+            in the breadcrumbs list
+
+        Returns
+        -------
+        list
+            Breadcrumbs suitable for the link_breadcrumbs() jinja macro
+        """
         provider_path = '/localfile'
         breadcrumbs = [{
             'url': url_path_join(self.base_url, self._localfile_path),
             'name': 'home'
         }]
-        breadcrumbs.extend(self.breadcrumbs(path, self._localfile_path))
+        breadcrumbs.extend(super(LocalFileHandler, self).breadcrumbs(path, self._localfile_path))
         return breadcrumbs
 
     @gen.coroutine
@@ -127,7 +141,7 @@ class LocalFileHandler(RenderingHandler):
                                    public=False,
                                    format=self.format,
                                    request=self.request,
-                                   breadcrumbs=self.localfile_breadcrumbs(path),
+                                   breadcrumbs=self.breadcrumbs(path),
                                    title=os.path.basename(path))
 
     def show_dir(self,  abspath,  path):
@@ -193,6 +207,6 @@ class LocalFileHandler(RenderingHandler):
 
         html = self.render_template('dirview.html',
                                     entries=entries,
-                                    breadcrumbs=self.localfile_breadcrumbs(path),
+                                    breadcrumbs=self.breadcrumbs(path),
                                     title=url_path_join(path, '/'))
         return html

--- a/nbviewer/providers/url/tests/test_url.py
+++ b/nbviewer/providers/url/tests/test_url.py
@@ -4,6 +4,7 @@
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
+import unittest
 
 import requests
 
@@ -13,7 +14,9 @@ class URLTestCase(NBViewerTestCase):
     def test_url(self):
         url = self.url('url/jdj.mit.edu/~stevenj/IJulia Preview.ipynb')
         r = requests.get(url)
-        self.assertIn(r.status_code, (200, 202))
+        # Base class overrides assertIn to do unicode in unicode checking
+        # We want to use the original unittest implementation
+        unittest.TestCase.assertIn(self, r.status_code, (200, 202))
         self.assertIn('Download Notebook', r.text)
 
 

--- a/nbviewer/providers/url/tests/test_url.py
+++ b/nbviewer/providers/url/tests/test_url.py
@@ -13,7 +13,7 @@ class URLTestCase(NBViewerTestCase):
     def test_url(self):
         url = self.url('url/jdj.mit.edu/~stevenj/IJulia Preview.ipynb')
         r = requests.get(url)
-        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 202)
         self.assertIn('Download Notebook', r.text)
 
 

--- a/nbviewer/providers/url/tests/test_url.py
+++ b/nbviewer/providers/url/tests/test_url.py
@@ -13,7 +13,7 @@ class URLTestCase(NBViewerTestCase):
     def test_url(self):
         url = self.url('url/jdj.mit.edu/~stevenj/IJulia Preview.ipynb')
         r = requests.get(url)
-        self.assertEqual(r.status_code, 202)
+        self.assertIn(r.status_code, (200, 202))
         self.assertIn('Download Notebook', r.text)
 
 

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -37,7 +37,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>{{title|default("Jupyter Notebook Viewer")}}</title>
+  <title>{{title|default("Jupyter Notebook Viewer", true)}}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="{{ description | default('') }}">
   <meta name="author" content="{{ author | default('') }}">


### PR DESCRIPTION
* Set directory name and filename as localfile page title
* Show path breadcrumbs for localfile notebooks
* Escape commas in download filenames