### PR TITLE
Add docker tests, updated travis CI to use docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ nbviewer.egg-info
 nbviewer/static/build
 nbviewer/static/components
 node_modules
+Makefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,12 @@
-language: python
+sudo: required
 
-node_js:
-- 6
-
-python:
-- 2.7
-- 3.5
-- 3.6
-
-before_install:
-- sudo apt-get update
-- sudo apt-get install -qq libzmq3-dev pandoc libcurl4-gnutls-dev libmemcached-dev
-- pip install --upgrade setuptools pip
-- pip install -r requirements-dev.txt
-- npm install .
+language: docker
 
 install:
-- pip install --upgrade setuptools pip
-- pip install -r requirements.txt
-- invoke bower
-- invoke less
+- make build
 
 script:
-- invoke test
+- make test
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,15 @@
-language: python
+sudo: required
 
-node_js:
-- 6
+language: "python"
+
+services:
+  - docker
 
 python:
-- 2.7
-- 3.5
-- 3.6
-
-before_install:
-- sudo apt-get update
-- sudo apt-get install -qq libzmq3-dev pandoc libcurl4-gnutls-dev libmemcached-dev
-- pip install --upgrade setuptools pip
-- pip install -r requirements-dev.txt
-- npm install .
+   - "3"
 
 install:
-- pip install --upgrade setuptools pip
-- pip install -r requirements.txt
-- invoke bower
-- invoke less
+   - "make build"
 
 script:
-- invoke test
-
-env:
-  global:
-  - secure: Sv53YMdsVTin1hUPRqIuvdAOJ0UwklEowW49qpxY9wSgiAM79D+e1b5Yxrn+RTtS3WGlvK1aKHICc+2ajccEJkKFL8WDy2SnTnoWPadrEy4NAGLkNMGK+bAYMnLNoNRbSGVz5JpvNJ7JkeaEplhJ572OJOxa1X7ZF9165ZbOWng=
-  - secure: ajFM7ch1/xYyEjusyTzd963GOOLg5/H0lxvQ7L6r+LBDDro79FxNPMcAkZxF7n24rkPO8I+AP3FfUwbQf4ShmGkAdsxSFMc2d7GDUowxiicPr5bMitygxlzl2ox2lWdpt4QldmEywbrCKKwt/cZkKxE8er9xBcwe7xw/2xUYOLk=
+   - "make test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,30 @@
-sudo: required
+language: python
 
-services:
-  - docker
+node_js:
+- 6
+
+python:
+- 2.7
+- 3.5
+- 3.6
+
+before_install:
+- sudo apt-get update
+- sudo apt-get install -qq libzmq3-dev pandoc libcurl4-gnutls-dev libmemcached-dev
+- pip install --upgrade setuptools pip
+- pip install -r requirements-dev.txt
+- npm install .
 
 install:
-   - "make build"
+- pip install --upgrade setuptools pip
+- pip install -r requirements.txt
+- invoke bower
+- invoke less
 
 script:
-   - "make test"
+- invoke test
+
+env:
+  global:
+  - secure: Sv53YMdsVTin1hUPRqIuvdAOJ0UwklEowW49qpxY9wSgiAM79D+e1b5Yxrn+RTtS3WGlvK1aKHICc+2ajccEJkKFL8WDy2SnTnoWPadrEy4NAGLkNMGK+bAYMnLNoNRbSGVz5JpvNJ7JkeaEplhJ572OJOxa1X7ZF9165ZbOWng=
+  - secure: ajFM7ch1/xYyEjusyTzd963GOOLg5/H0lxvQ7L6r+LBDDro79FxNPMcAkZxF7n24rkPO8I+AP3FfUwbQf4ShmGkAdsxSFMc2d7GDUowxiicPr5bMitygxlzl2ox2lWdpt4QldmEywbrCKKwt/cZkKxE8er9xBcwe7xw/2xUYOLk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 sudo: required
 
-language: "python"
-
 services:
   - docker
-
-python:
-   - "3"
 
 install:
    - "make build"

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,0 +1,9 @@
+FROM nbviewer_nbviewer
+
+USER root
+
+# python requirements
+ADD ./requirements-dev.txt /srv/nbviewer/
+RUN pip3 install --no-cache-dir --upgrade -r requirements-dev.txt && \
+    pip3 freeze
+

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM nbviewer_nbviewer
+FROM nbviewer
 
 USER root
 

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ build:
 
 test: build
 	docker build -t nbviewer_test -f Dockerfile.tests .
-	docker run -e GITHUB_API_TOKEN nbviewer_test python3 setup.py test
+	docker run -e GITHUB_API_TOKEN nbviewer_test invoke test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+build:
+	docker-compose build
+
+test: build
+	docker build -t nbviewer_test -f Dockerfile.tests .
+	docker run -e GITHUB_API_TOKEN nbviewer_test python3 setup.py test

--- a/README.md
+++ b/README.md
@@ -123,9 +123,19 @@ This will automatically relaunch the server if a change is detected on a python 
 
 #### Running the Tests
 
-`nose` is used to run the test suite. The tests currently make calls to
-external APIs such as GitHub, so it is best to use your Github API Token when
-running:
+`nose` is used to run the test suite, and it is easiest to extend the
+nbviewer docker to run the tests with all dependencies installed. A
+Makefile has been provided for this purpose.  The tests currently make
+calls to external APIs such as GitHub, so it is best to use your
+Github API Token when running:
+
+```shell
+$ cd <path to repo>
+$ GITHUB_API_TOKEN=<your token> make tests
+```
+
+If you wish to run the tests outside of the docker containers, the
+following code will do so:
 
 ```shell
 $ cd <path to repo>

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ This will automatically relaunch the server if a change is detected on a python 
 
 #### Running the Tests
 
-`nose` is used to run the test suite, and it is easiest to extend the
-nbviewer docker to run the tests with all dependencies installed. A
+`nose` is used to run the test suite, and it is easiest to extend
+the nbviewer docker to run the tests with all dependencies installed. A
 Makefile has been provided for this purpose.  The tests currently make
 calls to external APIs such as GitHub, so it is best to use your
 Github API Token when running:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Jupyter Notebook Viewer
 
+[![Build Status](https://travis-ci.org/jupyter/nbviewer.svg?branch=master)](https://travis-ci.org/jupyter/nbviewer)
+
 Jupyter nbviewer is the web application behind [The Jupyter Notebook Viewer](http://nbviewer.ipython.org), which is graciously hosted by [Rackspace](https://developer.rackspace.com/?nbviewer=awesome).
 
 Run this locally to get most of the features of nbviewer on your own network.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
-nbviewer:
-  build: .
-  links:
-  - nbcache
-  ports:
-   - 8080:8080
-nbcache:
-  image: memcached
+version: '2'
+services:
+  nbviewer:
+    build: .
+    image: nbviewer
+    links:
+    - nbcache
+    ports:
+    - 8080:8080
+  nbcache:
+    image: memcached

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "watch-less": "./node_modules/.bin/watch 'invoke less' ./nbviewer/static/less"
   },
   "devDependencies": {
-    "less": "*",
+    "less": "2.7.2",
     "less-plugin-autoprefix": "*",
     "less-plugin-clean-css": "*",
     "bower": "*",


### PR DESCRIPTION
This PR has added a testing docker image that can run the test cases successfully, and has updated the README and the travis.yml use the docker-based testing image.

I'm happy to modify this PR as needed to help it get to master.

Thanks!