### PR TITLE
Tidy up the localfile handler a little.

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -101,7 +101,9 @@ def init_handlers(formats, providers, base_url, localfiles):
 
     # Add localfile handlers if the option is set
     if localfiles:
-        providers.append('nbviewer.providers.local')
+        # Put local provider first as per the comment at
+        # https://github.com/jupyter/nbviewer/pull/727#discussion_r144448440.
+        providers.insert(0, 'nbviewer.providers.local')
 
     handlers = provider_handlers(providers)
 

--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -17,7 +17,6 @@ from .providers.base import (
     BaseHandler,
     format_prefix,
 )
-from .providers.local import LocalFileHandler
 
 #-----------------------------------------------------------------------------
 # Handler classes
@@ -100,10 +99,11 @@ def init_handlers(formats, providers, base_url, localfiles):
         (r'/(robots\.txt|favicon\.ico)', web.StaticFileHandler)
     ]
 
-    handlers = provider_handlers(providers)
-
     # Add localfile handlers if the option is set
-    handlers = [(r'/localfile/?(.*)', LocalFileHandler)]+handlers if localfiles else handlers
+    if localfiles:
+        providers.append('nbviewer.providers.local')
+
+    handlers = provider_handlers(providers)
 
     raw_handlers = (
         pre_providers +

--- a/nbviewer/providers/local/__init__.py
+++ b/nbviewer/providers/local/__init__.py
@@ -1,1 +1,1 @@
-from .handlers import LocalFileHandler
+from .handlers import LocalFileHandler, default_handlers

--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -53,7 +53,6 @@ class LocalFileHandler(RenderingHandler):
         list
             Breadcrumbs suitable for the link_breadcrumbs() jinja macro
         """
-        provider_path = '/localfile'
         breadcrumbs = [{
             'url': url_path_join(self.base_url, self._localfile_path),
             'name': 'home'
@@ -210,3 +209,12 @@ class LocalFileHandler(RenderingHandler):
                                     breadcrumbs=self.breadcrumbs(path),
                                     title=url_path_join(path, '/'))
         return html
+
+
+def default_handlers(handlers=[]):
+    """Tornado handlers"""
+
+    return handlers + [
+        (r'/localfile/?(.*)', LocalFileHandler),
+    ]
+

--- a/tasks.py
+++ b/tasks.py
@@ -14,7 +14,7 @@ import pip
 import invoke
 
 NOTEBOOK_VERSION = '5.1.0' # the notebook version whose LESS we will use
-NOTEBOOK_CHECKSUM = 'cf7094e06ab65d7cf8c43fefdf647736ef8a5da880ce4c8f351e10f888aaab9a' # sha256 checksum of notebook tarball
+NOTEBOOK_CHECKSUM = 'c35fccb55250688303f6ef35c3870f6f5a8df885ff4d9e5cfe1176a87be7fdda' # sha256 checksum of notebook tarball
 
 APP_ROOT = os.path.dirname(__file__)
 NPM_BIN = os.path.join(APP_ROOT, "node_modules", ".bin")


### PR DESCRIPTION
I'm updating my org's instance of nbviewer which has fairly bespoke localfile usage (to access a network mounted disk). I'm going to be making further tweaks for the org (e.g. ensuring some security measures), but here was a quick win for this repo.

Essentially, the localfile provider is brought into line with the other providers by giving it a default_handlers function. We make use of that by appending the local provider as a string when localfile is enabled.