### PR TITLE
Factorise some of the localfile checking code.

### DIFF
--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -103,7 +103,7 @@ class LocalFileHandler(RenderingHandler):
 
         if not abspath.startswith(self.localfile_path):
             app_log.warn("directory traversal attempt: '%s'" %
-                         self.localfile_path)
+                         abspath)
             return False
 
         if not os.path.exists(abspath):


### PR DESCRIPTION
I've factored out a first-pass "can this be shown" function to the localfile provider. In order to minimise some of the risk of localfile, I wanted the ability to only show files that are readable by all. I've included that piece here too, as I think it is a sensible security measure, but would be happy to take it out again if necessary.

This change also now makes the checking of hidden files symmetrical - previously you could render a hidden subdirectory and/or notebook if you knew what address to type.