### PR TITLE
Make the top-level handler slash invariant.

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -86,7 +86,7 @@ def format_handlers(formats, handlers):
 
 def init_handlers(formats, providers, base_url, localfiles):
     pre_providers = [
-        ('/', IndexHandler),
+        ('/?', IndexHandler),
         ('/index.html', IndexHandler),
         (r'/faq/?', FAQHandler),
         (r'/create/?', CreateHandler),


### PR DESCRIPTION
This is necessary when starting nbviewer with ``--base-url`` if you want to be able to visit the top level of the base-level. For instance:

```
python -m nbviewer --base-url=/foo
```

I get a 404 at ```localhost:5000/foo```, but not at ```localhost:5000/foo/```. This change fixes that.

Ping @minrk as *I think* you added this feature for jupyterhub?