### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
+  "name": "nbviewer",
+  "private": true,
   "scripts": {
     "watch-less": "./node_modules/.bin/watch 'invoke less' ./nbviewer/static/less"
   },
   "devDependencies": {
-    "less": "*",
-    "less-plugin-autoprefix": "*",
-    "less-plugin-clean-css": "*",
-    "bower": "*",
-    "watch": "*"
+    "bower": "~1.8.2",
+    "less": "~2",
+    "less-plugin-autoprefix": "~1.5.1",
+    "less-plugin-clean-css": "~1.5.1",
+    "watch": "~1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
-  "name": "nbviewer",
-  "private": true,
+  "name": "nbviewer-deps",
+  "version": "0.1.0",
+  "description": "Jupyter nbviewer build dependencies",
+  "readme": "README.md",
   "scripts": {
     "watch-less": "./node_modules/.bin/watch 'invoke less' ./nbviewer/static/less"
   },
@@ -10,5 +12,11 @@
     "less-plugin-autoprefix": "~1.5.1",
     "less-plugin-clean-css": "~1.5.1",
     "watch": "~1.0.2"
+  },
+  "author": "Jupyter Developers",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyter/nbviewer.git"
   }
 }


### PR DESCRIPTION
Fixes #730.

This updates `package.json` to not create as many warnings, etc.

The writing is on the wall for the actual build chain, though: bower itself has declared itself deprecated:
```
Step 10/21 : RUN npm install .
 ---> Running in d00fc6b984d7
npm WARN deprecated bower@1.8.2: ...psst! Your project can stop working at any moment because its dependencies can change. Prevent this by migrating to Yarn: https://bower.io/blog/2017/how-to-migrate-away-from-bower/
```

We should consider what's the least-effort way to get to a more sane stance w/r/t all the npm stuff.

Because of the "special" relationship with `notebook`'s current build stuff, nbconvert, and the expectations of anyone that has labored to make stuff work on nbviewer, we can't just kick bower and requirejs to the curb.