### PR TITLE
Add support for the Content-Security-Policy header

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -255,6 +255,7 @@ def make_app():
         hub_api_url=os.getenv('JUPYTERHUB_API_URL'),
         hub_base_url=os.getenv('JUPYTERHUB_BASE_URL'),
         ipywidgets_base_url=options.ipywidgets_base_url,
+        content_security_policy=options.content_security_policy,
     )
 
     if options.localfiles:
@@ -311,6 +312,7 @@ def init_options():
     define("statsd_prefix", default='nbviewer', help="Prefix to use for naming metrics sent to statsd", type=str)
     define("base_url", default='/', help='URL base for the server')
     define("ipywidgets_base_url", default="https://unpkg.com/", help="URL base for ipywidgets package", type=str)
+    define("content_security_policy", default="connect-src 'none';", help="Content-Security-Policy header setting", type=str)
 
 
 def main(argv=None):

--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -90,6 +90,9 @@ class BaseHandler(web.RequestHandler):
             **kwargs
         )
 
+    def set_default_headers(self):
+        self.add_header('Content-Security-Policy', self.content_security_policy)
+
     @gen.coroutine
     def prepare(self):
         """Check if the user is authenticated with JupyterHub if the hub
@@ -192,6 +195,10 @@ class BaseHandler(web.RequestHandler):
     @property
     def ipywidgets_base_url(self):
         return self.settings['ipywidgets_base_url']
+
+    @property
+    def content_security_policy(self):
+        return self.settings['content_security_policy']
 
     @property
     def statsd(self):


### PR DESCRIPTION
Adds a command line `--content_security_policy=<value>` option which becomes a `Content-Security-Policy: <value>` HTTP header in response to all requests. Makes it a little less scary to open notebooks of unknown origin and content.

The default value of `connect-src 'none';` is totally open for discussion but felt like a reasonable safeguard to me for people who might run the server locally. (It disallows XHR, WebSocket, Fetch, etc. to any domain.)