### PR TITLE
Fix URI transformation for query strings

### DIFF
--- a/nbviewer/providers/url/tests/test_url.py
+++ b/nbviewer/providers/url/tests/test_url.py
@@ -10,9 +10,20 @@ import requests
 
 from ....tests.base import NBViewerTestCase, FormatHTMLMixin
 
+
 class URLTestCase(NBViewerTestCase):
     def test_url(self):
         url = self.url('url/jdj.mit.edu/~stevenj/IJulia Preview.ipynb')
+        r = requests.get(url)
+        # Base class overrides assertIn to do unicode in unicode checking
+        # We want to use the original unittest implementation
+        unittest.TestCase.assertIn(self, r.status_code, (200, 202))
+        self.assertIn('Download Notebook', r.text)
+
+    def test_urls_with_querystring(self):
+        # This notebook is only available if the querystring is passed through.
+        # Notebook URL: https://bug1348008.bmoattachments.org/attachment.cgi?id=8860059
+        url = self.url('urls/bug1348008.bmoattachments.org/attachment.cgi/%3Fid%3D8860059')
         r = requests.get(url)
         # Base class overrides assertIn to do unicode in unicode checking
         # We want to use the original unittest implementation

--- a/nbviewer/tests/test_utils.py
+++ b/nbviewer/tests/test_utils.py
@@ -58,6 +58,9 @@ def test_transform_ipynb_uri():
         u'/url/example.org/ipynb'),
         ('https://gist.github.com/user/1234/raw/a1b2c3/file.ipynb',
         u'/urls/gist.github.com/user/1234/raw/a1b2c3/file.ipynb'),
+        ('https://gist.github.com/user/1234/raw/a1b2c3/file.ipynb?query=string&is=1',
+        u'/urls/gist.github.com/user/1234/raw/a1b2c3/file.ipynb/%3Fquery%3Dstring%26is%3D1'),
+
     )
     uri_rewrite_list = provider_uri_rewrites(default_rewrites)
     for ipynb_uri, expected_output in test_data:

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -112,7 +112,8 @@ def transform_ipynb_uri(uri, uri_rewrite_list):
     for reg, rewrite in uri_rewrite_list:
         matches = re.match(reg, uri)
         if matches:
-            return rewrite.format(*matches.groups())
+            uri = rewrite.format(*matches.groups())
+            break
 
     # encode query parameters as last url part
     if '?' in uri:
@@ -120,6 +121,7 @@ def transform_ipynb_uri(uri, uri_rewrite_list):
         uri = '%s/%s' % (uri, quote('?' + query))
 
     return uri
+
 
 # get_encoding_from_headers from requests.utils (1.2.3)
 # (c) 2013 Kenneth Reitz


### PR DESCRIPTION
[A comment](https://github.com/jupyter/nbviewer/issues/104#issuecomment-76996402) from @bollwyvl did not chime with my experience of nbviewer's handling of querystrings.

Given the suggestion, I assumed there was some code that was supposed to handle this, and indeed it appeared to be the case. For example, the url handler in [``nbviewer.handlers.url``](https://github.com/jupyter/nbviewer/blob/master/nbviewer/providers/url/handlers.py#L43) has a ``if '/?' in url:`` condition...

Turns out that this tiny bug fix turns on all the existing logic which wasn't currently being fired, and allows URLs with querystrings to be rendered, whilst maintaining the desire to user querysrtrings in the actual nbviewer URL (thus providing the ability to add querystrings to nbviewer in the future should they be so desired). 

Closes #690 and #725.