### PR TITLE
Removed unused function from import

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -36,7 +36,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from traitlets.config import Config
 
-from .handlers import init_handlers, format_handlers
+from .handlers import init_handlers
 from .cache import DummyAsyncCache, AsyncMultipartMemcache, MockCache, pylibmc
 from .index import NoSearch, ElasticSearch
 from .formats import configure_formats


### PR DESCRIPTION
While trying to figure out how `nbviewer` handles the tree navigation breadcrumb I found that function `format_handlers` is not used in `app.py` while at L#39 it has been imported.