### PR TITLE
Skip github tests when creds are not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ notebook-*
 .eggs/
 MANIFEST
 package-lock.json
+.vscode/

--- a/nbviewer/providers/gist/tests/test_gist.py
+++ b/nbviewer/providers/gist/tests/test_gist.py
@@ -8,24 +8,28 @@
 
 import requests
 
-from ....tests.base import NBViewerTestCase, FormatHTMLMixin
+from ....tests.base import NBViewerTestCase, FormatHTMLMixin, skip_unless_github_auth
 
 class GistTestCase(NBViewerTestCase):
+    @skip_unless_github_auth
     def test_gist(self):
         url = self.url('2352771')
         r = requests.get(url)
         self.assertEqual(r.status_code, 200)
 
+    @skip_unless_github_auth
     def test_gist_not_nb(self):
         url = self.url('6689377')
         r = requests.get(url)
         self.assertEqual(r.status_code, 400)
 
+    @skip_unless_github_auth
     def test_gist_no_such_file(self):
         url = self.url('6689377/no/file.ipynb')
         r = requests.get(url)
         self.assertEqual(r.status_code, 404)
 
+    @skip_unless_github_auth
     def test_gist_list(self):
         url = self.url('7518294')
         r = requests.get(url)
@@ -33,6 +37,7 @@ class GistTestCase(NBViewerTestCase):
         html = r.text
         self.assertIn('<th>Name</th>', html)
 
+    @skip_unless_github_auth
     def test_multifile_gist(self):
         url = self.url('7518294', 'Untitled0.ipynb')
         r = requests.get(url)
@@ -40,6 +45,7 @@ class GistTestCase(NBViewerTestCase):
         html = r.text
         self.assertIn('Download Notebook', html)
 
+    @skip_unless_github_auth
     def test_anonymous_gist(self):
         url = self.url('gist/4465051')
         r = requests.get(url)
@@ -47,6 +53,7 @@ class GistTestCase(NBViewerTestCase):
         html = r.text
         self.assertIn('Download Notebook', html)
 
+    @skip_unless_github_auth
     def test_gist_unicode(self):
         url = self.url('gist/amueller/3974344')
         r = requests.get(url)
@@ -54,6 +61,7 @@ class GistTestCase(NBViewerTestCase):
         html = r.text
         self.assertIn('<th>Name</th>', html)
 
+    @skip_unless_github_auth
     def test_gist_unicode_content(self):
         url = self.url('gist/ocefpaf/cf023a8db7097bd9fe92')
         r = requests.get(url)

--- a/nbviewer/providers/github/tests/test_github.py
+++ b/nbviewer/providers/github/tests/test_github.py
@@ -10,18 +10,21 @@ import requests
 
 from unittest import SkipTest
 
-from ....tests.base import NBViewerTestCase, FormatHTMLMixin
+from ....tests.base import NBViewerTestCase, FormatHTMLMixin, skip_unless_github_auth
 
 class GitHubTestCase(NBViewerTestCase):
+    @skip_unless_github_auth
     def ipython_example(self, *parts, **kwargs):
         ref = kwargs.get('ref', 'rel-2.0.0')
         return self.url('github/ipython/ipython/blob/%s/examples' % ref, *parts)
 
+    @skip_unless_github_auth
     def test_github(self):
         url = self.ipython_example('Index.ipynb')
         r = requests.get(url)
         self.assertEqual(r.status_code, 200)
 
+    @skip_unless_github_auth
     def test_github_unicode(self):
         url = self.url('github/tlapicka/IPythonNotebooks/blob',
             'ee6d2d13b96023e5f5e38e4516803eb22ede977e',
@@ -30,6 +33,7 @@ class GitHubTestCase(NBViewerTestCase):
         r = requests.get(url)
         self.assertEqual(r.status_code, 200)
 
+    @skip_unless_github_auth
     def test_github_blob_redirect_unicode(self):
         url = self.url('/urls/github.com/tlapicka/IPythonNotebooks/blob',
             'ee6d2d13b96023e5f5e38e4516803eb22ede977e',
@@ -40,6 +44,7 @@ class GitHubTestCase(NBViewerTestCase):
         # verify redirect
         self.assertIn('/github/tlapicka/IPythonNotebooks/blob/', r.request.url)
 
+    @skip_unless_github_auth
     def test_github_raw_redirect_unicode(self):
         url = self.url('/url/raw.github.com/tlapicka/IPythonNotebooks',
             'ee6d2d13b96023e5f5e38e4516803eb22ede977e',
@@ -50,11 +55,13 @@ class GitHubTestCase(NBViewerTestCase):
         # verify redirect
         self.assertIn('/github/tlapicka/IPythonNotebooks/blob/', r.request.url)
 
+    @skip_unless_github_auth
     def test_github_tag(self):
         url = self.ipython_example('Index.ipynb', ref='rel-2.0.0')
         r = requests.get(url)
         self.assertEqual(r.status_code, 200)
 
+    @skip_unless_github_auth
     def test_github_commit(self):
         url = self.ipython_example('Index.ipynb',
             ref='7f5cbd622058396f1f33c4b26c8d205a8dd26d16'
@@ -62,6 +69,7 @@ class GitHubTestCase(NBViewerTestCase):
         r = requests.get(url)
         self.assertEqual(r.status_code, 200)
 
+    @skip_unless_github_auth
     def test_github_blob_redirect(self):
         url = self.url(
             'urls/github.com/ipython/ipython/blob/rel-2.0.0/examples',
@@ -72,6 +80,7 @@ class GitHubTestCase(NBViewerTestCase):
         # verify redirect
         self.assertIn('/github/ipython/ipython/blob/master', r.request.url)
 
+    @skip_unless_github_auth
     def test_github_raw_redirect(self):
         url = self.url(
             'urls/raw.github.com/ipython/ipython/rel-2.0.0/examples',
@@ -82,7 +91,7 @@ class GitHubTestCase(NBViewerTestCase):
         # verify redirect
         self.assertIn('/github/ipython/ipython/blob/rel-2.0.0/examples', r.request.url)
 
-
+    @skip_unless_github_auth
     def test_github_rawusercontent_redirect(self):
         """Test GitHub's new raw domain"""
         url = self.url(
@@ -94,6 +103,7 @@ class GitHubTestCase(NBViewerTestCase):
         # verify redirect
         self.assertIn('/github/ipython/ipython/blob/rel-2.0.0/examples', r.request.url)
 
+    @skip_unless_github_auth
     def test_github_raw_redirect_2(self):
         """test /url/github.com/u/r/raw/ redirects"""
         url = self.url(
@@ -105,6 +115,7 @@ class GitHubTestCase(NBViewerTestCase):
         # verify redirect
         self.assertIn('/github/ipython/ipython/blob/rel-2.0.0', r.request.url)
 
+    @skip_unless_github_auth
     def test_github_repo_redirect(self):
         url = self.url("github/ipython/ipython")
         r = requests.get(url)
@@ -112,13 +123,14 @@ class GitHubTestCase(NBViewerTestCase):
         # verify redirect
         self.assertIn('/github/ipython/ipython/tree/master', r.request.url)
 
+    @skip_unless_github_auth
     def test_github_tree(self):
         url = self.url("github/ipython/ipython/tree/rel-2.0.0/IPython/")
         r = requests.get(url)
         self.assertEqual(r.status_code, 200)
         self.assertIn("__init__.py", r.text)
 
-
+    @skip_unless_github_auth
     def test_github_tree_redirect(self):
         url = self.url("github/ipython/ipython/tree/rel-2.0.0/MANIFEST.in")
         r = requests.get(url)
@@ -127,6 +139,7 @@ class GitHubTestCase(NBViewerTestCase):
         self.assertIn('/github/ipython/ipython/blob/rel-2.0.0', r.request.url)
         self.assertIn('global-exclude', r.text)
 
+    @skip_unless_github_auth
     def test_github_blob_redirect(self):
         url = self.url("github/ipython/ipython/blob/rel-2.0.0/IPython")
         r = requests.get(url)
@@ -135,6 +148,7 @@ class GitHubTestCase(NBViewerTestCase):
         self.assertIn('/github/ipython/ipython/tree/rel-2.0.0/IPython', r.request.url)
         self.assertIn('__init__.py', r.text)
 
+    @skip_unless_github_auth
     def test_github_ref_list(self):
         url = self.url('github/ipython/ipython/tree/master')
         r = requests.get(url)

--- a/nbviewer/tests/test_format_slides.py
+++ b/nbviewer/tests/test_format_slides.py
@@ -7,11 +7,12 @@
 
 import requests
 
-from .base import NBViewerTestCase
+from .base import NBViewerTestCase, skip_unless_github_auth
 from ..providers.local.tests.test_localfile import LocalFileDefaultTestCase
 
 
 class SlidesGistTestCase(NBViewerTestCase):
+    @skip_unless_github_auth
     def test_gist(self):
         url = self.url('/format/slides/0c5b3639b10ed3d7cc85/single-cell.ipynb')
         r = requests.get(url)
@@ -19,6 +20,7 @@ class SlidesGistTestCase(NBViewerTestCase):
         html = r.content
         self.assertIn('reveal.js', html)
 
+    @skip_unless_github_auth
     def test_html_exporter_link(self):
         url = self.url('/format/slides/0c5b3639b10ed3d7cc85/single-cell.ipynb')
         r = requests.get(url)
@@ -27,6 +29,7 @@ class SlidesGistTestCase(NBViewerTestCase):
         self.assertIn('/gist/minrk/0c5b3639b10ed3d7cc85/single-cell.ipynb', html)
         self.assertNotIn('//gist/minrk/0c5b3639b10ed3d7cc85/single-cell.ipynb', html)
 
+    @skip_unless_github_auth
     def test_no_slides_exporter_link(self):
         url = self.url('/0c5b3639b10ed3d7cc85/single-cell.ipynb')
         r = requests.get(url)
@@ -56,6 +59,7 @@ class SlidesGitHubTestCase(NBViewerTestCase):
             *parts
         )
 
+    @skip_unless_github_auth
     def test_github(self):
         url = self.ipython_example('Index.ipynb')
         r = requests.get(url)

--- a/nbviewer/tests/test_security.py
+++ b/nbviewer/tests/test_security.py
@@ -9,7 +9,7 @@
 import os
 import requests
 
-from .base import NBViewerTestCase
+from .base import NBViewerTestCase, skip_unless_github_auth
 
 from ..providers.local.tests.test_localfile import (
     LocalFileRelativePathTestCase as LFRPTC
@@ -21,11 +21,13 @@ class XSSTestCase(NBViewerTestCase):
         self.assertEqual(r.status_code, 200)
         self.assertNotIn(pattern, r.content)
 
+    @skip_unless_github_auth
     def test_github_dirnames(self):
         self._xss(
             '/github/bburky/xss/tree/%3Cscript%3Ealert(1)%3C%2fscript%3E/'
         )
 
+    @skip_unless_github_auth
     def test_gist_filenames(self):
         self._xss('/gist/bburky/c020825874798a6544a7')
 
@@ -39,6 +41,7 @@ class LocalDirectoryTraversalTestCase(LFRPTC):
 
 
 class URLLeakTestCase(NBViewerTestCase):
+    @skip_unless_github_auth
     def test_gist(self):
         url = self.url('/github/jupyter')
         r = requests.get(url)


### PR DESCRIPTION
Decorates github repo and gists tests so that they are skipped when the AsyncGitHubClient does not have a client id+secret or access token available to authenticate with the GitHub API.

The intent here is to clean up near-constant test failures due to GitHub API rate limiting on Travis CI. My hope is that meaningful test failures are easier to spot without all the noise, and contributors are not put-off by false alarms.

I thought about creating a new assertStatus method instead that allows the tests to run but ends early on 503 status, but saw little value since most of the test assertions are still missed after the initial 503.

Best we can do is watch for failures on merge to master where the encrypted GH creds are available to Travis.