### PR TITLE
Hotfix for jupyter widgets support regression.

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -255,7 +255,8 @@ def make_app():
         hub_api_url=os.getenv('JUPYTERHUB_API_URL'),
         hub_base_url=os.getenv('JUPYTERHUB_BASE_URL'),
         ipywidgets_base_url=options.ipywidgets_base_url,
-        ipywidgets_version_spec=options.ipywidgets_version_spec,
+        jupyter_widgets_html_manager_version=options.jupyter_widgets_html_manager_version,
+        jupyter_js_widgets_version=options.jupyter_js_widgets_version,
         content_security_policy=options.content_security_policy,
         binder_base_url=options.binder_base_url,
     )
@@ -314,7 +315,8 @@ def init_options():
     define("statsd_prefix", default='nbviewer', help="Prefix to use for naming metrics sent to statsd", type=str)
     define("base_url", default='/', help='URL base for the server')
     define("ipywidgets_base_url", default="https://unpkg.com/", help="URL base for ipywidgets JS package", type=str)
-    define("ipywidgets_version_spec", default="*", help="Version specifier for ipywidgets JS package", type=str)
+    define("jupyter_js_widgets_version", default="*", help="Version specifier for jupyter-js-widgets JS package", type=str)
+    define("jupyter_widgets_html_manager_version", default="*", help="Version specifier for @jupyter-widgets/html-manager JS package", type=str)
     define("content_security_policy", default="connect-src 'none';", help="Content-Security-Policy header setting", type=str)
     define("binder_base_url", default="https://mybinder.org/v2", help="URL base for binder notebook execution service", type=str)
 

--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -197,8 +197,12 @@ class BaseHandler(web.RequestHandler):
         return self.settings['ipywidgets_base_url']
 
     @property
-    def ipywidgets_version_spec(self):
-        return self.settings['ipywidgets_version_spec']
+    def jupyter_js_widgets_version(self):
+        return self.settings['jupyter_js_widgets_version']
+
+    @property
+    def jupyter_widgets_html_manager_version(self):
+        return self.settings['jupyter_widgets_html_manager_version']
 
     @property
     def content_security_policy(self):
@@ -271,7 +275,8 @@ class BaseHandler(web.RequestHandler):
             "from_base": self.from_base,
             "google_analytics_id": self.settings.get('google_analytics_id'),
             "ipywidgets_base_url": self.ipywidgets_base_url,
-            "ipywidgets_version_spec": self.ipywidgets_version_spec
+            "jupyter_js_widgets_version": self.jupyter_js_widgets_version,
+            "jupyter_widgets_html_manager_version": self.jupyter_widgets_html_manager_version,
         }
 
     def breadcrumbs(self, path, base_url):

--- a/nbviewer/templates/notebook.html
+++ b/nbviewer/templates/notebook.html
@@ -91,14 +91,14 @@
         function addWidgetsRenderer() {
           var mimeElement = document.querySelector('script[type="application/vnd.jupyter.widget-view+json"]');
           var scriptElement = document.createElement('script');
-          var widgetRendererSrc = '{{ ipywidgets_base_url }}@jupyter-widgets/html-manager@{{ ipywidgets_version_spec }}/dist/embed-amd.js';
+          var widgetRendererSrc = '{{ ipywidgets_base_url }}@jupyter-widgets/html-manager@{{ jupyter_widgets_html_manager_version }}/dist/embed-amd.js';
           var widgetState;
 
           try {
             widgetState = mimeElement && JSON.parse(mimeElement.innerHTML);
 
             if (widgetState && (widgetState.version_major < 2 || !widgetState.version_major)) {
-              widgetRendererSrc = '{{ ipywidgets_base_url }}jupyter-js-widgets@{{ ipywidgets_version_spec }}/dist/embed.js';
+              widgetRendererSrc = '{{ ipywidgets_base_url }}jupyter-js-widgets@{{ jupyter_js_widgets_version }}/dist/embed.js';
             }
           } catch(e) {}
 

--- a/tasks.py
+++ b/tasks.py
@@ -13,8 +13,8 @@ from tarfile import TarFile
 
 import invoke
 
-NOTEBOOK_VERSION = '5.7.7' # the notebook version whose LESS we will use
-NOTEBOOK_CHECKSUM = '19df5755bc21bb1f711e6415f6f620bf7c71cb6c8318a25bc151fe31bdfe4047' # sha256 checksum of notebook tarball
+NOTEBOOK_VERSION = '5.7.8' # the notebook version whose LESS we will use
+NOTEBOOK_CHECKSUM = '573e0ae650c5d76b18b6e564ba6d21bf321d00847de1d215b418acb64f056eb8' # sha256 checksum of notebook tarball
 
 APP_ROOT = os.path.dirname(__file__)
 NPM_BIN = os.path.join(APP_ROOT, "node_modules", ".bin")


### PR DESCRIPTION
Allow specifying versions of jupyter-js-widgets and @jupyter-widgets/html-manager separately on the command line when launching nbviewer.

For #823, fixup for #818 workaround started in #821. Tested locally with 

```
python -m nbviewer --jupyter_js_widgets_version=2.1 --jupyter_widgets_html_manager_version=0.15
```

and pointing at the broken notebook in #823.