### PR TITLE
Additional logging for file permission issues

### DIFF
--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -115,7 +115,7 @@ class LocalFileHandler(RenderingHandler):
             return False
 
         if not os.path.exists(fullpath):
-            app_log.warn("path: '%s' does not exist" % fullpath)
+            app_log.warn("path: '%s' does not exist", fullpath)
             return False
 
         if any(part.startswith('.') or part.startswith('_')
@@ -127,12 +127,12 @@ class LocalFileHandler(RenderingHandler):
 
             # Ensure the file/directory has other read access for all.
             if not fstat.st_mode & stat.S_IROTH:
-                app_log.warn("path: '%s' does not have read permissions" % fullpath)
+                app_log.warn("path: '%s' does not have read permissions", fullpath)
                 return False
 
             if os.path.isdir(fullpath) and not fstat.st_mode & stat.S_IXOTH:
                 # skip directories we can't execute (i.e. list)
-                app_log.warn("path: '%s' does not have execute permissions" % fullpath)
+                app_log.warn("path: '%s' does not have execute permissions", fullpath)
                 return False
 
         return True
@@ -156,7 +156,7 @@ class LocalFileHandler(RenderingHandler):
         fullpath = os.path.join(self.localfile_path, path)
 
         if not self.can_show(fullpath):
-            app_log.info("path: '%s' is not visible from within nbviewer" % fullpath)
+            app_log.info("path: '%s' is not visible from within nbviewer", fullpath)
             raise web.HTTPError(404)
 
         if os.path.isdir(fullpath):
@@ -174,7 +174,7 @@ class LocalFileHandler(RenderingHandler):
         except IOError as ex:
             if ex.errno == errno.EACCES:
                 # py2/3: can't read the file, so don't give away it exists
-                app_log.info("path : '%s' is not readable from within nbviewer" % fullpath)
+                app_log.info("path : '%s' is not readable from within nbviewer", fullpath)
                 raise web.HTTPError(404)
             raise ex
 
@@ -211,7 +211,7 @@ class LocalFileHandler(RenderingHandler):
         except IOError as ex:
             if ex.errno == errno.EACCES:
                 # py2/3: can't access the dir, so don't give away its presence
-                app_log.info("contents of path: '%s' cannot be listed from within nbviewer" % fullpath)
+                app_log.info("contents of path: '%s' cannot be listed from within nbviewer", fullpath)
                 raise web.HTTPError(404)
 
         for f in contents:

--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -115,6 +115,7 @@ class LocalFileHandler(RenderingHandler):
             return False
 
         if not os.path.exists(fullpath):
+            app_log.warn("path: '%s' does not exist" % fullpath)
             return False
 
         if any(part.startswith('.') or part.startswith('_')
@@ -126,10 +127,12 @@ class LocalFileHandler(RenderingHandler):
 
             # Ensure the file/directory has other read access for all.
             if not fstat.st_mode & stat.S_IROTH:
+                app_log.warn("path: '%s' does not have read permissions" % fullpath)
                 return False
 
             if os.path.isdir(fullpath) and not fstat.st_mode & stat.S_IXOTH:
                 # skip directories we can't execute (i.e. list)
+                app_log.warn("path: '%s' does not have execute permissions" % fullpath)
                 return False
 
         return True
@@ -153,6 +156,7 @@ class LocalFileHandler(RenderingHandler):
         fullpath = os.path.join(self.localfile_path, path)
 
         if not self.can_show(fullpath):
+            app_log.info("path: '%s' is not visible from within nbviewer" % fullpath)
             raise web.HTTPError(404)
 
         if os.path.isdir(fullpath):
@@ -170,6 +174,7 @@ class LocalFileHandler(RenderingHandler):
         except IOError as ex:
             if ex.errno == errno.EACCES:
                 # py2/3: can't read the file, so don't give away it exists
+                app_log.info("path : '%s' is not readable from within nbviewer" % fullpath)
                 raise web.HTTPError(404)
             raise ex
 
@@ -206,6 +211,7 @@ class LocalFileHandler(RenderingHandler):
         except IOError as ex:
             if ex.errno == errno.EACCES:
                 # py2/3: can't access the dir, so don't give away its presence
+                app_log.info("contents of path: '%s' cannot be listed from within nbviewer" % fullpath)
                 raise web.HTTPError(404)
 
         for f in contents:


### PR DESCRIPTION
- Added warning logs for instances where the `local` provider encounters file permission issues (https://github.com/jupyter/nbviewer/issues/828)