### PR TITLE
(1) Fixed FAQ page, (2) made front page compatible with JupyterHub

### DIFF
--- a/nbviewer/frontpage.json
+++ b/nbviewer/frontpage.json
@@ -8,17 +8,17 @@
      "links":[
        {
          "text": "IPython",
-         "target": "github/ipython/ipython/blob/6.x/examples/IPython%20Kernel/Index.ipynb",
+         "target": "/github/ipython/ipython/blob/6.x/examples/IPython%20Kernel/Index.ipynb",
          "img": "/static/img/example-nb/ipython-thumb.png"
        },
        {
          "text": "IRuby",
-         "target": "github/SciRuby/sciruby-notebooks/blob/master/getting_started.ipynb",
+         "target": "/github/SciRuby/sciruby-notebooks/blob/master/getting_started.ipynb",
          "img": "/static/img/example-nb/iruby-nb.png"
        },
        {
          "text": "IJulia",
-         "target": "url/jdj.mit.edu/~stevenj/IJulia%20Preview.ipynb",
+         "target": "/url/jdj.mit.edu/~stevenj/IJulia%20Preview.ipynb",
          "img": "/static/img/example-nb/ijulia-preview.png"
        }
      ]
@@ -28,17 +28,17 @@
      "links":[
        {
          "text": "Python for Signal Processing",
-         "target": "github/unpingco/Python-for-Signal-Processing/",
+         "target": "/github/unpingco/Python-for-Signal-Processing/",
          "img": "/static/img/example-nb/python-signal.png"
        },
        {
          "text": "O'Reilly Book",
-         "target": "github/ptwobrussell/Mining-the-Social-Web-2nd-Edition/tree/master/ipynb",
+         "target": "/github/ptwobrussell/Mining-the-Social-Web-2nd-Edition/tree/master/ipynb",
          "img": "/static/img/example-nb/mining-slice.png"
        },
        {
          "text": "Probabilistic Programming",
-         "target": "github/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/blob/master/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb",
+         "target": "/github/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/blob/master/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb",
          "img": "/static/img/example-nb/probabilistic-bayesian.png"
        }
      ]
@@ -48,47 +48,47 @@
      "links":[
        {
          "text": "Data Visualization with Lightning",
-         "target": "github/lightning-viz/lightning-example-notebooks/blob/master/index.ipynb",
+         "target": "/github/lightning-viz/lightning-example-notebooks/blob/master/index.ipynb",
          "img": "/static/img/example-nb/lightning.png"
        },
        {
          "text": "Interactive data visualization with Bokeh",
-         "target": "github/bokeh/bokeh-notebooks/blob/master/index.ipynb",
+         "target": "/github/bokeh/bokeh-notebooks/blob/master/index.ipynb",
          "img": "/static/img/example-nb/bokeh.png"
        },
        {
          "text": "Interactive plots with Plotly",
-         "target": "github/plotly/python-user-guide/blob/master/Index.ipynb",
+         "target": "/github/plotly/python-user-guide/blob/master/Index.ipynb",
          "img": "/static/img/example-nb/plotly.png"
        },
        {
          "text": "XKCD Plot With Matplotlib",
-         "target": "url/jakevdp.github.com/downloads/notebooks/XKCD_plots.ipynb",
+         "target": "/url/jakevdp.github.com/downloads/notebooks/XKCD_plots.ipynb",
          "img": "/static/img/example-nb/XKCD-Matplotlib.png"
        },
        {
          "text": "Python for Vision Research",
-         "target": "github/gestaltrevision/python_for_visres/blob/master/index.ipynb",
+         "target": "/github/gestaltrevision/python_for_visres/blob/master/index.ipynb",
          "img": "/static/img/example-nb/python_for_visres.png"
        },
        {
          "text": "Non Parametric Regression",
-         "target": "gist/fonnesbeck/2352771",
+         "target": "/gist/fonnesbeck/2352771",
          "img": "/static/img/example-nb/covariance.png"
        },
        {
          "text": "Partial Differential Equations Solver",
-         "target": "github/waltherg/notebooks/blob/master/2013-12-03-Crank_Nicolson.ipynb",
+         "target": "/github/waltherg/notebooks/blob/master/2013-12-03-Crank_Nicolson.ipynb",
          "img": "/static/img/example-nb/pde_solver_with_numpy.png"
        },
        {
          "text": "Analysis of current events",
-         "target": "gist/darribas/4121857",
+         "target": "/gist/darribas/4121857",
          "img": "/static/img/example-nb/gaza.png"
        },
        {
          "text": "Jaynes-Cummings model",
-         "target": "github/jrjohansson/qutip-lectures/blob/master/Lecture-1-Jaynes-Cumming-model.ipynb",
+         "target": "/github/jrjohansson/qutip-lectures/blob/master/Lecture-1-Jaynes-Cumming-model.ipynb",
          "img": "/static/img/example-nb/jaynes-cummings.png"
        }
      ]

--- a/nbviewer/templates/faq.md
+++ b/nbviewer/templates/faq.md
@@ -4,7 +4,7 @@
 
 <div class="col-md-10 col-md-offset-1">
 
-{% filter markdown(extensions=['headerid(level=3)','toc'], extension_configs= {'toc' : [('anchorlink', True)]}) %}
+{% filter markdown(extensions=['toc'], extension_configs= {'toc' : [('anchorlink', True)]}) %}
 
 # Frequently Asked Questions
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 elasticsearch
 jupyter_client
-markdown
+markdown>=3.0
 newrelic!=2.80.0.60
 nbformat>=4.2
 nbconvert>=5.4


### PR DESCRIPTION
**(1)** Currently the Jinja2 in the `faq.md` file references a Python-Markdown extension, "HeaderId", which was removed from Python-Markdown in 2018; see this commit:

https://github.com/Python-Markdown/markdown/commit/11270135194922e0f5cfc739b69fe39f7337a0f9

Also, according to that commit, the HeaderId extension was deprecated and then removed from Python-Markdown because it can be replaced entirely by the `toc` extension, which is already referenced in the `faq.md` file.

Therefore, when trying to run nbviewer locally, with `faq.md`, and clicking on the FAQ link from the front page, one hits a "500 Internal Server Error" page, and the log files show that the error is
```ModuleNotFoundError: No module named 'headerid(level=3)'```.

After I removed the reference to `headerId` in `faq.md` and re-ran nbviewer locally, the FAQ page loaded correctly (no 500 Internal Server Error) and looked like the corresponding FAQ page on nbviewer.jupyter.org, which presumably is the intended behavior.

**(2)** With the way `frontpage.json` was currently written, when one clicked on any of the links on the front page, when nbviewer was hosted as a(n externally managed) service on JupyterHub, the link would take the user to, e.g. `baseURL/hub/services/gist/fonnesbeck/2352771` instead of the intended behavior `baseURL/services/nbviewer/gist/fonnesbeck/2352771`. In the former case we get a 404 error, whereas in the latter case nbviewer actually pulls up the intended files.

The root URL for nbviewer when hosted as a JupyterHub service is `baseURL/services/nbviewer`. In order to interact with nbviewer, the GET requests all have to be to URLs underneath this. So in particular in order to avoid 404ing and to actually interact with the nbviewer service instead of the hub itself, it's necessary for the URIs on the front page to send the user to URLs starting with `baseURL/services/nbviewer`. Any other prefix, e.g. `baseURL/hub/services/` causes 404 errors. The intended behavior doesn't happen without the beginning `/` in the URI. I don't know why, but URIs starting with the empty string have the incorrect prefix `baseURL/hub/services` prepended, while URIs starting with `/` have the correct prefix `baseURL/services/nbviewer` prepended.

**Comments:**
These are minor bugs and what is proposed is a minor fix -- hopefully it is still worth your consideration.

@parente I'm not sure who is the maintainer of this project right now.