### PR TITLE
Reorganize init_tornado_application, create some configurables

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -25,7 +25,7 @@ from tornado.options import define, options
 
 from jinja2 import Environment, FileSystemLoader
 
-from traitlets import Unicode
+from traitlets import Unicode, Any, Set, default
 from traitlets.config import Application
 
 from .handlers import init_handlers
@@ -74,83 +74,96 @@ FRONTPAGE_JSON = os.path.join(this_dir, "frontpage.json")
 
 class NBViewer(Application):
 
+    name = Unicode('nbviewer')
+
     config_file = Unicode('nbviewer_config.py', help="The config file to load").tag(config=True)
 
-    def init_tornado_application(self):
-        # NBConvert config
-        self.config.NbconvertApp.fileext = 'html'
-        self.config.CSSHTMLHeaderTransformer.enabled = False
+    url_handler         = Unicode(default_value="nbviewer.providers.url.handlers.URLHandler",           help="The Tornado handler to use for viewing notebooks accessed via URL").tag(config=True)
+    local_handler       = Unicode(default_value="nbviewer.providers.local.handlers.LocalFileHandler",   help="The Tornado handler to use for viewing notebooks found on a local filesystem").tag(config=True)
+    github_blob_handler = Unicode(default_value="nbviewer.providers.github.handlers.GitHubBlobHandler", help="The Tornado handler to use for viewing notebooks stored as blobs on GitHub").tag(config=True)
+    github_tree_handler = Unicode(default_value="nbviewer.providers.github.handlers.GitHubTreeHandler", help="The Tornado handler to use for viewing directory trees on GitHub").tag(config=True)
+    gist_handler        = Unicode(default_value="nbviewer.providers.gist.handlers.GistHandler",         help="The Tornado handler to use for viewing notebooks stored as GitHub Gists").tag(config=True)
+    user_gists_handler  = Unicode(default_value="nbviewer.providers.gist.handlers.UserGistsHandler",    help="The Tornado handler to use for viewing directory containing all of a user's Gists").tag(config=True)
 
-        # DEBUG env implies both autoreload and log-level
-        if os.environ.get("DEBUG"):
-            options.debug = True
-            logging.getLogger().setLevel(logging.DEBUG)
-    
-        # setup memcache
-        mc_pool = ThreadPoolExecutor(options.mc_threads)
-    
-        # setup formats
-        formats = configure_formats(options, self.config, log.app_log)
-    
-        if options.processes:
-            pool = ProcessPoolExecutor(options.processes)
-        else:
-            pool = ThreadPoolExecutor(options.threads)
-    
-        memcache_urls = os.environ.get('MEMCACHIER_SERVERS',
-            os.environ.get('MEMCACHE_SERVERS')
-        )
-    
-        # Handle linked Docker containers
-        if(os.environ.get('NBCACHE_PORT')):
-            tcp_memcache = os.environ.get('NBCACHE_PORT')
-            memcache_urls = tcp_memcache.split('tcp://')[1]
-    
-        if(os.environ.get('NBINDEX_PORT')):
+    index = Any().tag(config=True)
+    @default('index')
+    def _load_index(self):
+        if os.environ.get('NBINDEX_PORT'):
             log.app_log.info("Indexing notebooks")
             tcp_index = os.environ.get('NBINDEX_PORT')
             index_url = tcp_index.split('tcp://')[1]
             index_host, index_port = index_url.split(":")
-            indexer = ElasticSearch(index_host, index_port)
         else:
             log.app_log.info("Not indexing notebooks")
             indexer = NoSearch()
-    
+        return indexer
+
+    # cache frontpage links for the maximum allowed time
+    max_cache_uris = Set().tag(config=True)
+    @default('max_cache_uris')
+    def _load_max_cache_uris(self):
+        max_cache_uris = {''}
+        for section in self.frontpage_setup['sections']:
+            for link in section['links']:
+                max_cache_uris.add('/' + link['target'])
+        return max_cache_uris
+
+    static_path = Unicode(default_value=pjoin(here, 'static')).tag(config=True)
+
+    static_url_prefix = Unicode().tag(config=True)
+    @default('static_url_prefix')
+    def _load_static_url_prefix(self):
+        return url_path_join(self.base_url, '/static/')
+
+    @property
+    def base_url(self):
+        # prefer the JupyterHub defined service prefix over the CLI
+        base_url = os.getenv("JUPYTERHUB_SERVICE_PREFIX", options.base_url)
+        return base_url
+
+    @property
+    def cache(self):
+        memcache_urls = os.environ.get('MEMCACHIER_SERVERS', os.environ.get('MEMCACHE_SERVERS'))
+        # Handle linked Docker containers
+        if os.environ.get('NBCACHE_PORT'):
+            tcp_memcache = os.environ.get('NBCACHE_PORT')
+            memcache_urls = tcp_memcache.split('tcp://')[1]
         if options.no_cache:
             log.app_log.info("Not using cache")
             cache = MockCache()
         elif pylibmc and memcache_urls:
+            # setup memcache
+            mc_pool = ThreadPoolExecutor(options.mc_threads)
             kwargs = dict(pool=mc_pool)
-            username = os.environ.get('MEMCACHIER_USERNAME', '')
-            password = os.environ.get('MEMCACHIER_PASSWORD', '')
+            username = os.environ.get("MEMCACHIER_USERNAME", "")
+            password = os.environ.get("MEMCACHIER_PASSWORD", "")
             if username and password:
                 kwargs['binary'] = True
                 kwargs['username'] = username
                 kwargs['password'] = password
                 log.app_log.info("Using SASL memcache")
             else:
-                log.app_log.info("Using plain memecache")
-    
-            cache = AsyncMultipartMemcache(memcache_urls.split(','), **kwargs)
+                log.app_log.info("Using plain memcache")
+
+            cache = AsyncMultiPartMemcache(memcache_urls.split(','), **kwargs)
         else:
             log.app_log.info("Using in-memory cache")
             cache = DummyAsyncCache()
-    
-        # setup tornado handlers and settings
-    
-        template_paths = pjoin(here, 'templates')
-    
-        if options.template_path is not None:
-            log.app_log.info("Using custom template path {}".format(
-                options.template_path)
-            )
-            template_paths = [options.template_path, template_paths]
-    
-        static_path = pjoin(here, 'static')
-        env = Environment(
-            loader=FileSystemLoader(template_paths),
-            autoescape=True
-        )
+
+        return cache
+
+    # for some reason this needs to be a computed property,
+    # and not a traitlets Any(), otherwise nbviewer won't run
+    @property
+    def client(self):
+        AsyncHTTPClient.configure(HTTPClientClass)
+        client = AsyncHTTPClient()
+        client.cache = self.cache
+        return client
+
+    @property
+    def env(self):
+        env = Environment(loader=FileSystemLoader(self.template_paths), autoescape=True)
         env.filters['markdown'] = markdown.markdown
         try:
             git_data = git_info(here)
@@ -159,105 +172,136 @@ class NBViewer(Application):
             git_data = {}
         else:
             git_data['msg'] = escape(git_data['msg'])
-    
-    
+
         if options.no_cache:
-            # force jinja to recompile template every time
+            # force Jinja2 to recompile template every time
             env.globals.update(cache_size=0)
-        env.globals.update(nrhead=nrhead, nrfoot=nrfoot, git_data=git_data,
-            jupyter_info=jupyter_info(), len=len,
-        )
-        AsyncHTTPClient.configure(HTTPClientClass)
-        client = AsyncHTTPClient()
-        client.cache = cache
-    
-        # load frontpage sections
-        with io.open(options.frontpage, 'r') as f:
-            frontpage_setup = json.load(f)
-        # check if the json has a 'sections' field, otherwise assume it is
-        # just a list of sessions, and provide the defaults for the other
-        # fields
-        if 'sections' not in frontpage_setup:
-            frontpage_setup = {'title': 'nbviewer',
-                               'subtitle':
-                               'A simple way to share Jupyter Notebooks',
-                               'show_input': True,
-                               'sections': frontpage_setup}
-    
-        # cache frontpage links for the maximum allowed time
-        max_cache_uris = {''}
-        for section in frontpage_setup['sections']:
-            for link in section['links']:
-                max_cache_uris.add('/' + link['target'])
-    
+        env.globals.update(nrhead=nrhead, nrfoot=nrfoot, git_data=git_data, jupyter_info=jupyter_info(), len=len)
+
+        return env
+
+    @property
+    def fetch_kwargs(self):
         fetch_kwargs = dict(connect_timeout=10,)
         if options.proxy_host:
-            fetch_kwargs.update(dict(proxy_host=options.proxy_host,
-                                     proxy_port=options.proxy_port))
-    
+            fetch_kwargs.update(proxy_host=options.proxy_host, proxy_port=options.proxy_port)
             log.app_log.info("Using web proxy {proxy_host}:{proxy_port}."
                              "".format(**fetch_kwargs))
-    
-        if options.no_check_certificate:
-            fetch_kwargs.update(dict(validate_cert=False))
-    
-            log.app_log.info("Not validating SSL certificates")
-    
-        # prefer the jhub defined service prefix over the CLI
-        base_url = os.getenv('JUPYTERHUB_SERVICE_PREFIX', options.base_url)
         
-        rate_limiter = RateLimiter(
-            limit=options.rate_limit,
-            interval=options.rate_limit_interval,
-            cache=cache,
-        )
-    
+        if options.no_check_certificate:
+            fetch_kwargs.update(validate_cert=False)
+            log.app_log.info("Not validating SSL certificates")
+
+        return fetch_kwargs
+
+    @property
+    def formats(self):
+        formats = configure_formats(options, self.config, log.app_log)
+        return formats
+
+    # load frontpage sections
+    @property
+    def frontpage_setup(self):
+        with io.open(options.frontpage, 'r') as f:
+            frontpage_setup = json.load(f)
+        # check if the JSON has a 'sections' field, otherwise assume it is just a list of sessions,
+        # and provide the defaults of the other fields
+        if 'sections' not in frontpage_setup:
+            frontpage_setup = {
+                              'title':'nbviewer', 'subtitle':'A simple way to share Jupyter notebooks',
+                              'show_input':True, 'sections':frontpage_setup
+                              }
+        return frontpage_setup
+
+    @property
+    def pool(self):
+        if options.processes:
+            pool = ProcessPoolExecutor(options.processes)
+        else:
+            pool = ThreadPoolExecutor(options.threads)
+        return pool
+
+    @property
+    def rate_limiter(self):
+        rate_limiter = RateLimiter(limit=options.rate_limit, interval=options.rate_limit_interval, cache=self.cache)
+        return rate_limiter
+
+    @property
+    def template_paths(self):
+        template_paths = pjoin(here, 'templates')
+        if options.template_path is not None:
+            log.app_log.info("Using custom template path {}".format(options.template_path))
+            template_paths = [options.template_path, template_paths]
+
+        return template_paths
+
+
+    def init_tornado_application(self):
+        # handle handlers
+        handlers = init_handlers(self.formats, options.providers, self.base_url, options.localfiles)
+        
+        # NBConvert config
+        self.config.NbconvertApp.fileext = 'html'
+        self.config.CSSHTMLHeaderTransformer.enabled = False
+
+        # DEBUG env implies both autoreload and log-level
+        if os.environ.get("DEBUG"):
+            options.debug = True
+            logging.getLogger().setLevel(logging.DEBUG)
+   
+        # input traitlets to settings
         settings = dict(
-            log_function=log_request,
-            jinja2_env=env,
-            static_path=static_path,
-            static_url_prefix=url_path_join(base_url, '/static/'),
-            client=client,
-            formats=formats,
-            default_format=options.default_format,
-            providers=options.providers,
-            provider_rewrites=options.provider_rewrites,
-            config=self.config,
-            index=indexer,
-            cache=cache,
-            cache_expiry_min=options.cache_expiry_min,
-            cache_expiry_max=options.cache_expiry_max,
-            max_cache_uris=max_cache_uris,
-            frontpage_setup=frontpage_setup,
-            pool=pool,
-            gzip=True,
-            render_timeout=options.render_timeout,
-            localfile_path=os.path.abspath(options.localfiles),
-            localfile_follow_symlinks=options.localfile_follow_symlinks,
-            localfile_any_user=options.localfile_any_user,
-            fetch_kwargs=fetch_kwargs,
-            mathjax_url=options.mathjax_url,
-            rate_limiter=rate_limiter,
-            statsd_host=options.statsd_host,
-            statsd_port=options.statsd_port,
-            statsd_prefix=options.statsd_prefix,
-            base_url=base_url,
-            google_analytics_id=os.getenv('GOOGLE_ANALYTICS_ID'),
-            hub_api_token=os.getenv('JUPYTERHUB_API_TOKEN'),
-            hub_api_url=os.getenv('JUPYTERHUB_API_URL'),
-            hub_base_url=os.getenv('JUPYTERHUB_BASE_URL'),
-            ipywidgets_base_url=options.ipywidgets_base_url,
-            jupyter_widgets_html_manager_version=options.jupyter_widgets_html_manager_version,
-            jupyter_js_widgets_version=options.jupyter_js_widgets_version,
-            content_security_policy=options.content_security_policy,
-            binder_base_url=options.binder_base_url,
+                  config=self.config,
+                  index=self.index,
+                  max_cache_uris=self.max_cache_uris,
+                  static_path=self.static_path,
+                  static_url_prefix=self.static_url_prefix,
         )
-    
+        # input computed properties to settings
+        settings.update(
+                  base_url=self.base_url,
+                  cache=self.cache,
+                  client=self.client,
+                  fetch_kwargs=self.fetch_kwargs,
+                  formats=self.formats,
+                  frontpage_setup=self.frontpage_setup,
+                  jinja2_env=self.env,
+                  pool=self.pool,
+                  rate_limiter=self.rate_limiter,
+        )
+        # input settings from CLI options
+        settings.update(
+                  binder_base_url=options.binder_base_url,
+                  cache_expiry_max=options.cache_expiry_max,
+                  cache_expiry_min=options.cache_expiry_min,
+                  content_security_policy=options.content_security_policy,
+                  default_format=options.default_format,
+                  ipywidgets_base_url=options.ipywidgets_base_url,
+                  jupyter_js_widgets_version=options.jupyter_js_widgets_version,
+                  jupyter_widgets_html_manager_version=options.jupyter_widgets_html_manager_version,
+                  localfile_any_user=options.localfile_any_user,
+                  localfile_follow_symlinks=options.localfile_follow_symlinks,
+                  localfile_path=os.path.abspath(options.localfiles),
+                  mathjax_url=options.mathjax_url,
+                  provider_rewrites=options.provider_rewrites,
+                  providers=options.providers,
+                  render_timeout=options.render_timeout,
+                  statsd_host=options.statsd_host,
+                  statsd_port=options.statsd_port,
+                  statsd_prefix=options.statsd_prefix,
+        )
+        # additional settings
+        settings.update(
+                  google_analytics_id=os.getenv('GOOGLE_ANALYTICS_ID'),
+                  gzip=True,
+                  hub_api_token=os.getenv('JUPYTERHUB_API_TOKEN'),
+                  hub_api_url=os.getenv('JUPYTERHUB_API_URL'),
+                  hub_base_url=os.getenv('JUPYTERHUB_BASE_URL'),
+                  log_function=log_request,
+        )
+
         if options.localfiles:
             log.app_log.warning("Serving local notebooks in %s, this can be a security risk", options.localfiles)
-    
-        # handle handlers
-        handlers = init_handlers(formats, options.providers, base_url, options.localfiles)
     
         # create the app
         self.tornado_application = web.Application(handlers, debug=options.debug, **settings)

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -8,6 +8,8 @@
 from base64 import encodebytes
 from base64 import decodebytes
 
+from functools import lru_cache
+
 import cgi
 from contextlib import contextmanager
 import re
@@ -247,3 +249,6 @@ def time_block(message, debug_limit=1):
     dt = time.time() - tic
     log = app_log.info if dt > debug_limit else app_log.debug
     log("%s in %.2f ms", message, 1e3 * dt)
+
+def cached_property(method):
+    return property(lru_cache(1)(method))


### PR DESCRIPTION
Reorganized `init_tornado_application` by creating class properties for the `NBViewer` class, as well as a couple of attributes which are configurable traitlets (and thus can be modified from `nbviewer_config.py`). 

The main principle was: if the variable which was later used in `settings` depended on one of the `options.foo`, then for now the correct way to configure it should be exclusively through the command line (since the command line configuration is not yet compatible with traitlets), and so it should be made a property of the `NBViewer` class. 

Otherwise, it should be made a configurable traitlets instance, with a default value computed using the `@default` decorator from traitlets. 

However, I was not able to apply this principle to to `client` (using an instance of `Any`), since when I did so NBViewer was unable to start (it complained of being unable to find `settings['hub_base_url']` when trying to compute the value of the `hub_base_url` property of `BaseHandler`, even though `hub_base_url` _was_ an entry of `settings`, which suggested that somehow something was fundamentally wrong and the settings were not being correctly understood by the handlers). So in violation of the general rule above I made it a computed property instead.

Also I alphabetized some of the lines of code using Vim sort so that it might be quicker to find things, although admittedly it probably makes the diff more difficult to read.

Anyway, at least in principle, none of the code is changed, and instead it has just been reorganized, exploiting the existence of the new `NBViewer` class.