### PR TITLE
Fix repo and user links for GHE

### DIFF
--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -388,17 +388,27 @@ def uri_rewrites(rewrites=[]):
     ]
     # github enterprise
     if os.environ.get('GITHUB_API_URL', '') != '':
-        github_api_url = os.environ.get('GITHUB_API_URL')
+        github_url = os.environ.get('GITHUB_API_URL').split('api/v3')[0]
 
         github_rewrites.extend([
             # raw view
-            (r'^' + github_api_url.split('/api/v3/')[0]
-                + '/([^\/]+)/([^\/]+)/raw/([^\/]+)/(.*)',
+            (r'^' + github_url
+                + r'([^\/]+)/([^\/]+)/raw/([^\/]+)/(.*)',
                 u'/github/{0}/{1}/blob/{2}/{3}'),
 
             # trees & blobs
-            (r'^' + github_api_url.split('/api/v3/')[0]
-                + '/([\w\-]+)/([^\/]+)/(blob|tree)/(.*)$',
+            (r'^' + github_url
+                + r'([\w\-]+)/([^\/]+)/(blob|tree)/(.*)$',
                 u'/github/{0}/{1}/{2}/{3}'),
+
+            # user/repo
+            (r'^' + github_url
+                + r'([\w\-]+)/([^\/]+)/?$',
+                u'/github/{0}/{1}/tree/master'),
+
+            # user
+            (r'^' + github_url
+                + r'([\w\-]+)$',
+                u'/github/{0}/'),
         ])
     return rewrites + github_rewrites

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -388,26 +388,26 @@ def uri_rewrites(rewrites=[]):
     ]
     # github enterprise
     if os.environ.get('GITHUB_API_URL', '') != '':
-        github_url = os.environ.get('GITHUB_API_URL').split('api/v3')[0]
+        github_base_url = os.environ.get('GITHUB_API_URL').split('api/v3')[0]
 
         github_rewrites.extend([
             # raw view
-            (r'^' + github_url
+            (r'^' + github_base_url
                 + r'([^\/]+)/([^\/]+)/raw/([^\/]+)/(.*)',
                 u'/github/{0}/{1}/blob/{2}/{3}'),
 
             # trees & blobs
-            (r'^' + github_url
+            (r'^' + github_base_url
                 + r'([\w\-]+)/([^\/]+)/(blob|tree)/(.*)$',
                 u'/github/{0}/{1}/{2}/{3}'),
 
             # user/repo
-            (r'^' + github_url
+            (r'^' + github_base_url
                 + r'([\w\-]+)/([^\/]+)/?$',
                 u'/github/{0}/{1}/tree/master'),
 
             # user
-            (r'^' + github_url
+            (r'^' + github_base_url
                 + r'([\w\-]+)/?$',
                 u'/github/{0}/'),
         ])

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -408,7 +408,7 @@ def uri_rewrites(rewrites=[]):
 
             # user
             (r'^' + github_url
-                + r'([\w\-]+)$',
+                + r'([\w\-]+)/?$',
                 u'/github/{0}/'),
         ])
     return rewrites + github_rewrites


### PR DESCRIPTION
Closes #863.

> **Describe the bug**
> When configured to integrate with GitHub Enterprise, links to repositories and users/orgs do not work.
> 
> Examples:
> 
>     * https://ghe.mycompany.com/ivangomes
> 
>     * https://ghe.mycompany.com/ivangomes/myproject
> 
> 
> **To Reproduce**
> Enter GHE URL like https://ghe.mycompany.com/ivangomes in an nbviewer deployment configured with GHE.
> 
> **Expected behavior**
> Get redirected to https://nbviewer.mycompany.com/github/ivangomes and see the navigation UI, like in https://nbviewer.jupyter.org/github/jupyter/nbviewer/tree/master/
> 
> **Additional context**
> Related to #850.

