### PR TITLE
Fix raw download for GHE

### DIFF
--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -262,8 +262,12 @@ class GitHubBlobHandler(GithubClientMixin, RenderingHandler):
     @cached
     @gen.coroutine
     def get(self, user, repo, ref, path):
-        raw_url = u"https://raw.githubusercontent.com/{user}/{repo}/{ref}/{path}".format(
-            user=user, repo=repo, ref=ref, path=quote(path)
+        if os.environ.get('GITHUB_API_URL', '') == '':
+            raw_pattern = u"https://raw.githubusercontent.com/{user}/{repo}/{ref}/{path}"
+        else: #Github Enterprise has a different URL pattern for accessing raw files
+            raw_pattern = u"{github_url}{user}/{repo}/raw/{ref}/{path}"
+        raw_url = raw_pattern.format(
+            user=user, repo=repo, ref=ref, path=quote(path), github_url=self.github_url
         )
         blob_url = u"{github_url}{user}/{repo}/blob/{ref}/{path}".format(
             user=user, repo=repo, ref=ref, path=quote(path), github_url=_github_url()

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -29,6 +29,7 @@ from ...utils import (
     base64_decode,
     quote,
     response_text,
+    url_path_join,
 )
 
 from .client import AsyncGitHubClient
@@ -291,12 +292,13 @@ class GitHubBlobHandler(GithubClientMixin, RenderingHandler):
     @gen.coroutine
     def get_notebook_data(self, user, repo, ref, path):
         if os.environ.get('GITHUB_API_URL', '') == '':
-            raw_pattern = u"https://raw.githubusercontent.com/{user}/{repo}/{ref}/{path}"
+            raw_url = u"https://raw.githubusercontent.com/{user}/{repo}/{ref}/{path}".format(
+                user=user, repo=repo, ref=ref, path=quote(path)
+            )
         else: #Github Enterprise has a different URL pattern for accessing raw files
-            raw_pattern = u"{github_url}{user}/{repo}/raw/{ref}/{path}"
-        raw_url = raw_pattern.format(
-            user=user, repo=repo, ref=ref, path=quote(path), github_url=self.github_url
-        )
+            raw_url = url_path_join(
+                self.github_url, user, repo, 'raw', ref, quote(path)
+            )
         blob_url = u"{github_url}{user}/{repo}/blob/{ref}/{path}".format(
             user=user, repo=repo, ref=ref, path=quote(path), github_url=self.github_url
         )


### PR DESCRIPTION
Closes #867.
> **Describe the bug**
> When configured to integrate with GitHub Enterprise, raw download links for notebooks do not work.
> 
> **To Reproduce**
> With a notebook from GHE open, e.g. https://nbviewer.mycompany.com/github/ivangomes/myproject/index.ipynb, in an nbviewer configured GITHUB_API_URL=https://ghe.mycompany.com/v3/api/, click the download button on the top right and get a 404.
> 
> **Expected behavior**
> File download from GHE starts.
> 
> **Additional context**
> Related to #850, #863, #865.

