### PR TITLE
Fix #869 from cgi import escape fails under python 3.8; import from html instead

### DIFF
--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -12,7 +12,7 @@ import time
 import statsd
 import asyncio
 
-from cgi import escape
+from html import escape
 from contextlib import contextmanager
 from datetime import datetime
 


### PR DESCRIPTION
replace line 15 of providers/base.py with
`from html import escape`