### PR TITLE
Step7_6 (custom static path now behaves same as custom template path)

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -43,7 +43,7 @@ try: # Python 3.8
 except ImportError:
     from .utils import cached_property
 
-from notebook.base.handlers import FileFindHandler as StaticFileHandler
+from jupyter_server.base.handlers import FileFindHandler as StaticFileHandler
 
 #-----------------------------------------------------------------------------
 # Code

--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -43,6 +43,8 @@ try: # Python 3.8
 except ImportError:
     from .utils import cached_property
 
+from notebook.base.handlers import FileFindHandler as StaticFileHandler
+
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
@@ -122,12 +124,16 @@ class NBViewer(Application):
                 max_cache_uris.add('/' + link['target'])
         return max_cache_uris
 
-    static_path = Unicode(default_value=pjoin(here, 'static')).tag(config=True)
+    static_path = Unicode(default_value=os.environ.get("NBVIEWER_STATIC_PATH", ""), help="Custom path for loading additional static files.").tag(config=True)
 
-    static_url_prefix = Unicode().tag(config=True)
-    @default('static_url_prefix')
+    static_url_prefix = Unicode(default_value='/static/').tag(config=True)
+
+    # Not exposed to end user for configuration, since needs to access base_url
+    _static_url_prefix = Unicode()
+    @default('_static_url_prefix')
     def _load_static_url_prefix(self):
-        return url_path_join(self.base_url, '/static/')
+        # Last '/' ensures that NBViewer still works regardless of whether user chooses e.g. '/static2/' pr '/static2' as their custom prefix
+        return url_path_join(self.base_url, self.static_url_prefix, '/')
 
     @cached_property
     def base_url(self):
@@ -232,14 +238,24 @@ class NBViewer(Application):
         return rate_limiter
 
     @cached_property
+    def static_paths(self):
+        default_static_path = pjoin(here, 'static')
+        if self.static_path:
+            log.app_log.info("Using custom static path {}".format(self.static_path))
+            static_paths = [self.static_path, default_static_path]
+        else:
+            static_paths = [default_static_path]
+        return static_paths
+
+    @cached_property
     def template_paths(self):
-        template_paths = pjoin(here, 'templates')
+        default_template_path = pjoin(here, 'templates')
         if options.template_path is not None:
             log.app_log.info("Using custom template path {}".format(options.template_path))
-            template_paths = [options.template_path, template_paths]
-
+            template_paths = [options.template_path, default_template_path]
+        else:
+            template_paths = [default_template_path]
         return template_paths
-
 
     def init_tornado_application(self):
         # handle handlers
@@ -270,6 +286,8 @@ class NBViewer(Application):
    
         # input traitlets to settings
         settings = dict(
+                  # Allow FileFindHandler to load static directories from e.g. a Docker container
+                  allow_remote_access=True,
                   base_url=self.base_url,
                   binder_base_url=options.binder_base_url,
                   cache=self.cache,
@@ -303,8 +321,10 @@ class NBViewer(Application):
                   providers=options.providers,
                   rate_limiter=self.rate_limiter,
                   render_timeout=options.render_timeout,
-                  static_path=self.static_path,
-                  static_url_prefix=self.static_url_prefix,
+                  static_handler_class = StaticFileHandler,
+                  # FileFindHandler expects list of static paths, so self.static_path*s* is correct
+                  static_path=self.static_paths,
+                  static_url_prefix=self._static_url_prefix,
                   statsd_host=options.statsd_host,
                   statsd_port=options.statsd_port,
                   statsd_prefix=options.statsd_prefix,

--- a/nbviewer/frontpage.json
+++ b/nbviewer/frontpage.json
@@ -9,17 +9,17 @@
        {
          "text": "IPython",
          "target": "/github/ipython/ipython/blob/6.x/examples/IPython%20Kernel/Index.ipynb",
-         "img": "/static/img/example-nb/ipython-thumb.png"
+         "img": "/img/example-nb/ipython-thumb.png"
        },
        {
          "text": "IRuby",
          "target": "/github/SciRuby/sciruby-notebooks/blob/master/getting_started.ipynb",
-         "img": "/static/img/example-nb/iruby-nb.png"
+         "img": "/img/example-nb/iruby-nb.png"
        },
        {
          "text": "IJulia",
          "target": "/url/jdj.mit.edu/~stevenj/IJulia%20Preview.ipynb",
-         "img": "/static/img/example-nb/ijulia-preview.png"
+         "img": "/img/example-nb/ijulia-preview.png"
        }
      ]
    },
@@ -29,17 +29,17 @@
        {
          "text": "Python for Signal Processing",
          "target": "/github/unpingco/Python-for-Signal-Processing/",
-         "img": "/static/img/example-nb/python-signal.png"
+         "img": "/img/example-nb/python-signal.png"
        },
        {
          "text": "O'Reilly Book",
          "target": "/github/ptwobrussell/Mining-the-Social-Web-2nd-Edition/tree/master/ipynb",
-         "img": "/static/img/example-nb/mining-slice.png"
+         "img": "/img/example-nb/mining-slice.png"
        },
        {
          "text": "Probabilistic Programming",
          "target": "/github/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/blob/master/Chapter1_Introduction/Ch1_Introduction_PyMC3.ipynb",
-         "img": "/static/img/example-nb/probabilistic-bayesian.png"
+         "img": "/img/example-nb/probabilistic-bayesian.png"
        }
      ]
    },
@@ -49,47 +49,47 @@
        {
          "text": "Data Visualization with Lightning",
          "target": "/github/lightning-viz/lightning-example-notebooks/blob/master/index.ipynb",
-         "img": "/static/img/example-nb/lightning.png"
+         "img": "/img/example-nb/lightning.png"
        },
        {
          "text": "Interactive data visualization with Bokeh",
          "target": "/github/bokeh/bokeh-notebooks/blob/master/index.ipynb",
-         "img": "/static/img/example-nb/bokeh.png"
+         "img": "/img/example-nb/bokeh.png"
        },
        {
          "text": "Interactive plots with Plotly",
          "target": "/github/plotly/python-user-guide/blob/master/Index.ipynb",
-         "img": "/static/img/example-nb/plotly.png"
+         "img": "/img/example-nb/plotly.png"
        },
        {
          "text": "XKCD Plot With Matplotlib",
          "target": "/url/jakevdp.github.com/downloads/notebooks/XKCD_plots.ipynb",
-         "img": "/static/img/example-nb/XKCD-Matplotlib.png"
+         "img": "/img/example-nb/XKCD-Matplotlib.png"
        },
        {
          "text": "Python for Vision Research",
          "target": "/github/gestaltrevision/python_for_visres/blob/master/index.ipynb",
-         "img": "/static/img/example-nb/python_for_visres.png"
+         "img": "/img/example-nb/python_for_visres.png"
        },
        {
          "text": "Non Parametric Regression",
          "target": "/gist/fonnesbeck/2352771",
-         "img": "/static/img/example-nb/covariance.png"
+         "img": "/img/example-nb/covariance.png"
        },
        {
          "text": "Partial Differential Equations Solver",
          "target": "/github/waltherg/notebooks/blob/master/2013-12-03-Crank_Nicolson.ipynb",
-         "img": "/static/img/example-nb/pde_solver_with_numpy.png"
+         "img": "/img/example-nb/pde_solver_with_numpy.png"
        },
        {
          "text": "Analysis of current events",
          "target": "/gist/darribas/4121857",
-         "img": "/static/img/example-nb/gaza.png"
+         "img": "/img/example-nb/gaza.png"
        },
        {
          "text": "Jaynes-Cummings model",
          "target": "/github/jrjohansson/qutip-lectures/blob/master/Lecture-1-Jaynes-Cumming-model.ipynb",
-         "img": "/static/img/example-nb/jaynes-cummings.png"
+         "img": "/img/example-nb/jaynes-cummings.png"
        }
      ]
    }

--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -232,6 +232,10 @@ class BaseHandler(web.RequestHandler):
         return self.settings['rate_limiter']
 
     @property
+    def static_url_prefix(self):
+        return self.settings['static_url_prefix']
+
+    @property
     def statsd(self):
         if hasattr(self, '_statsd'):
             return self._statsd
@@ -285,6 +289,10 @@ class BaseHandler(web.RequestHandler):
             "jupyter_js_widgets_version": self.jupyter_js_widgets_version,
             "jupyter_widgets_html_manager_version": self.jupyter_widgets_html_manager_version,
         }
+
+    # Overwrite the static_url method from Tornado to work better with our custom StaticFileHandler
+    def static_url(self, url):
+        return url_path_join(self.static_url_prefix, url)
 
     def breadcrumbs(self, path, base_url):
         """Generate a list of breadcrumbs"""

--- a/nbviewer/templates/index.html
+++ b/nbviewer/templates/index.html
@@ -41,7 +41,7 @@
             <li class="col-md-4">
               <p class="marketing-byline">{{link.text}}</p>
               <a class="thumbnail" href="{{ from_base(link.target) }}" target="_blank">
-                <img src="{{ from_base(link.img) }}" />
+                <img src="{{ static_url(link.img) }}" />
               </a>
             </li>
           {% endfor %}

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -58,7 +58,7 @@
   <![endif]-->
 
   <!-- Le fav and touch icons -->
-  <link rel="shortcut icon" href="/static/ico/ipynb_icon_16x16.png">
+  <link rel="shortcut icon" href="{{ static_url("ico/ipynb_icon_16x16.png") }}">
   <link rel="apple-touch-icon-precomposed" sizes="144x144"
         href="{{ static_url("ico/apple-touch-icon-144-precomposed.png") }}">
   <link rel="apple-touch-icon-precomposed" sizes="114x114"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ elasticsearch
 jupyter_client
 markdown>=3.0
 newrelic!=2.80.0.60
+notebook>=5.0
 nbformat>=4.2
 nbconvert>=5.4
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 elasticsearch
 jupyter_client
+jupyter_server>=0.2.0
 markdown>=3.0
 newrelic!=2.80.0.60
-notebook>=5.0
 nbformat>=4.2
 nbconvert>=5.4
 ipython


### PR DESCRIPTION
Changes to static file handling to facilitate customization. In particular, custom static paths now behave the same way that custom template paths do.

This involved changing the `static_url` method of `BaseHandler` to be different from the Tornado default. Moreover, the custom static file handler from notebook (instead of the default Tornado static file handler) is used (since it supports loading static files from multiple directories).
