### PR TITLE
Step7_7 (prepare base_url for traitlets by making it "private")

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ $ docker run -p 8080:8080 -e 'GITHUB_OAUTH_KEY=YOURKEY' \
 
 With this configured all GitHub API requests will go to your Enterprise instance so you can view all of your internal notebooks.
 
+## Base URL
+
+If the environment variable `JUPYTERHUB_SERVICE_PREFIX` is specified, then NBViewer _always_ uses the value of this environment variable as the base URL.
+
+In the case that there is no value for `JUPYTERHUB_SERVICE_PREFIX`, then as a backup the value of the `--base-url` flag passed to the `python -m nbviewer` command on the command line will be used as the base URL.
+
 ## Local Development
 
 ### With Docker

--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -132,14 +132,13 @@ class NBViewer(Application):
     _static_url_prefix = Unicode()
     @default('_static_url_prefix')
     def _load_static_url_prefix(self):
-        # Last '/' ensures that NBViewer still works regardless of whether user chooses e.g. '/static2/' pr '/static2' as their custom prefix
-        return url_path_join(self.base_url, self.static_url_prefix, '/')
+        # Last '/' ensures that NBViewer still works regardless of whether user chooses e.g. '/static2/' or '/static2' as their custom prefix
+        return url_path_join(self._base_url, self.static_url_prefix, '/')
 
+    # prefer the JupyterHub defined service prefix over the CLI
     @cached_property
-    def base_url(self):
-        # prefer the JupyterHub defined service prefix over the CLI
-        base_url = os.getenv("JUPYTERHUB_SERVICE_PREFIX", options.base_url)
-        return base_url
+    def _base_url(self):
+        return os.getenv("JUPYTERHUB_SERVICE_PREFIX", options.base_url)
 
     @cached_property
     def cache(self):
@@ -273,7 +272,7 @@ class NBViewer(Application):
                   user_gists_handler=self.user_gists_handler,
         )
         handler_kwargs = {'handler_names' : handler_names, 'handler_settings' : self.handler_settings}
-        handlers = init_handlers(self.formats, options.providers, self.base_url, options.localfiles, **handler_kwargs)
+        handlers = init_handlers(self.formats, options.providers, self._base_url, options.localfiles, **handler_kwargs)
         
         # NBConvert config
         self.config.NbconvertApp.fileext = 'html'
@@ -288,7 +287,7 @@ class NBViewer(Application):
         settings = dict(
                   # Allow FileFindHandler to load static directories from e.g. a Docker container
                   allow_remote_access=True,
-                  base_url=self.base_url,
+                  base_url=self._base_url,
                   binder_base_url=options.binder_base_url,
                   cache=self.cache,
                   cache_expiry_max=options.cache_expiry_max,


### PR DESCRIPTION
For traitlets, the CLI specified value _always_ overwrites the available default, whereas for `base_url` we want the opposite behavior, i.e. for the default (an environment variable) to _always_ overwrite the CLI specified value, if the default is available.

Therefore, the solution I thought of was to make the "true" value of base url private, and to have the value specified on the CLI to just be the back-up value in case the `JUPYTERHUB_SERVICE_PREFIX` environment variable isn't available. 

Come to think of it, this behavior should probably be explicitly documented somewhere, since it might be counterintuitive to someone expecting typical traitlets behavior.