### PR TITLE
Step7_8 (Add ability to write default config file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,13 @@ publishing, and we'd love to hear from you.
 
 #### Config file
 
-Newer versions of NBViewer will be configurable using a config file, `nbviewer_config.py`. In the directory where you run the command `python -m nbviewer` to start NBViewer, also add a file `nbviewer_config.py` which uses [the standard configuration syntax for Jupyter projects](https://traitlets.readthedocs.io/en/stable/config.html). 
+NBViewer is configurable using a config file, by default called `nbviewer_config.py`. You can modify the name and location of the config file that NBViewer looks for using the `--config-file` command line flag. (The location is always a relative path, i.e. relative to where the command `python -m nbviewer` is run, and never an absolute path.) 
 
-For example, to configure the value of a configurable `foo`, add the line `c.NBViewer.foo = 'bar'` to the `nbviewer_config.py` file located where you run `python -m nbviewer`. Again, currently very few features of NBViewer are configurable this way, but we hope to steadily increase the number of configurable characteristics of NBViewer in future releases.
+If you don't know which attributes of NBViewer you can configure using the config file, run `python -m nbviewer --generate-config` (or `python -m nbviewer --generate-config --config-file="my_custom_name.py"`) to write a default config file which has all of the configurable options commented out and set to their default values. To change a configurable option to a new value, uncomment the corresponding line and change the default value to the new value.
+
+The config file uses [the standard configuration syntax for Jupyter projects](https://traitlets.readthedocs.io/en/stable/config.html).
+
+One thing this allows you to do, for example, is to write your custom implementations of any of the standard page rendering [handlers](https://www.tornadoweb.org/en/stable/guide/structure.html#subclassing-requesthandler) included in NBViewer, e.g. by subclassing the original handlers to include custom logic along with custom output possibilities, and then have these custom handlers always loaded by default, by modifying the corresponding lines in the config file. This is effectively another way to extend NBViewer.
 
 ## Securing the Notebook Viewer
 

--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -334,7 +334,7 @@ class NBViewer(Application):
         self.tornado_application = web.Application(handlers, debug=options.debug, **settings)
 
     # Mostly copied from JupyterHub because if it isn't broken then don't fix it
-    def write_config(self):
+    def write_config_file(self):
         """Write our default config to a .py config file"""
         config_file_dir = os.path.dirname(os.path.abspath(options.config_file))
         if not os.path.isdir(config_file_dir):

--- a/nbviewer/tests/test_app.py
+++ b/nbviewer/tests/test_app.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+from tempfile import NamedTemporaryFile
+from subprocess import Popen
+
+# Also copied mostly from JupyterHub since again -- if not broken, don't fix.
+def test_generate_config():
+    with NamedTemporaryFile(prefix='nbviewer_config', suffix='.py') as tf:
+        cfg_file = tf.name
+    with open(cfg_file, 'w') as f:
+        f.write("c.A = 5")
+    p = Popen(
+        [sys.executable, '-m', 'nbviewer', '--generate-config', '--config-file={}'.format(cfg_file)],
+        stdout=PIPE,
+        stdin=PIPE,
+    )
+    out, _ = p.communicate(b'n')
+    out = out.decode('utf8', 'replace')
+    assert os.path.exists(cfg_file)
+    with open(cfg_file) as f:
+        cfg_text = f.read()
+    assert cfg_text == 'c.A = 5'
+
+    p = Popen(
+        [sys.executable, '-m', 'nbviewer', '--generate-config', '--config-file={}'.format(cfg_file)],
+        stdout=PIPE,
+        stdin=PIPE,
+    )
+    out, _ = p.communicate(b'x\ny')
+    out = out.decode('utf8', 'replace')
+    assert os.path.exists(cfg_file)
+    with open(cfg_file) as f:
+        cfg_text = f.read()
+    os.remove(cfg_file)
+    assert cfg_file in out
+    assert 'NBViewer.name' in cfg_text
+    assert 'NBViewer.static_path' in cfg_text

--- a/nbviewer/tests/test_app.py
+++ b/nbviewer/tests/test_app.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from tempfile import NamedTemporaryFile
+from subprocess import PIPE
 from subprocess import Popen
 
 # Also copied mostly from JupyterHub since again -- if not broken, don't fix.
@@ -34,5 +35,6 @@ def test_generate_config():
         cfg_text = f.read()
     os.remove(cfg_file)
     assert cfg_file in out
-    assert 'NBViewer.name' in cfg_text
+    assert 'NBViewer.name' not in cfg_text # This shouldn't be configurable
+    assert 'NBViewer.local_handler' in cfg_text
     assert 'NBViewer.static_path' in cfg_text


### PR DESCRIPTION
Note that `options.answer_yes`, `options.generate_config`, and `options.config_file` will all be turned into traitlets upon the transfer from `tornado.options` to `traitlets`. Writing them as `tornado.options` for now was just a provisional step so I could write this commit before the `tornado.options -> traitlets` commit, which will necessarily have a large diff. So splitting as much off from that diff as possible seems optimal.