### PR TITLE
Step7_10 (Make configure_formats method of NBViewer)

### DIFF
--- a/nbviewer/formats.py
+++ b/nbviewer/formats.py
@@ -5,11 +5,6 @@
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 
-import os
-
-from nbconvert.exporters.export import exporter_map
-
-
 def default_formats():
     """
     Return the currently-implemented formats.
@@ -76,29 +71,3 @@ def default_formats():
             'content_type': 'text/plain; charset=UTF-8'
         }
     }
-
-
-def configure_formats(options, config, log, formats=None):
-    """
-    Format-specific configuration.
-    """
-    if formats is None:
-        formats = default_formats()
-
-    # This would be better defined in a class
-    config.HTMLExporter.template_file = 'basic'
-    config.SlidesExporter.template_file = 'slides_reveal'
-
-    config.TemplateExporter.template_path = [
-        os.path.join(os.path.dirname(__file__), "templates", "nbconvert")
-    ]
-
-    for key, format in formats.items():
-        exporter_cls = format.get("exporter", exporter_map[key])
-        if options.processes:
-            # can't pickle exporter instances,
-            formats[key]["exporter"] = exporter_cls
-        else:
-            formats[key]["exporter"] = exporter_cls(config=config, log=log)
-
-    return formats


### PR DESCRIPTION
Make configure_formats a method of `NBViewer` to prepare for deletion of the options object with transition from `tornado.options` to `traitlets`.

In particular, the `configure_formats` function as written in `formats.py` depended on the `options` argument created by `tornado.options` in order to access the value of "`options.processes`".

After the transition from `tornado.options` to `traitlets`, any reference to `options.processes` will need to be replaced by a reference to `self.processes` inside of the `NBViewer` class. Therefore in order to access that value, `configure_formats` needs to be a method of `NBViewer`. 

(Or somehow it would be necessary to pass the entire application to `configure_formats`, if it were left as its own standalone function in `formats.py`, and then access `nbviewer.processes` if `nbviewer = NBViewer()`, but that seems like overkill and to be honest I don't think I would know how to do it anyway. Whereas I could figure out how to do this.)

This involves a _temporary_ feature regression inasmuch as changing `options.processes` to a traitlet `self.processes` before the `tornado.options -> traitlets` transition begins/is completed means that the only way to configure `processes` will _temporarily_ be via `nbviewer_config.py`, and impossible via the command line (which is currently parsed by `tornado.options`).

(I tried to ease the transition by having both `tornado.options` and `traitlets` parse the command line simultaneously when I first wrote this, but to make a long story short basically everything broke and it was necessary to change everything from `tornado.options` to `traitlets` at the same time, which is what I initially did, or accept _temporary_ regressions, like I'm doing now, where some features that used to be configurable via the CLI become _temporarily_ configurable only via a config file. This is a main, if not the main, reason why I originally insisted on trying to keep Step7 as a single PR for such a long time, even though it involves numerous changed lines of code.)

However, once the transition to `traitlets` is completed, this will _not_ be a feature regression, and will instead be a feature _enhancement_, since then `processes` will be configurable via _both_ the CLI and via a config file.
