### PR TITLE
Step7_11 (Unify and update logging)

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -5,7 +5,6 @@
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 from tornado import web
-from tornado.log import app_log
 
 from .utils import transform_ipynb_uri, url_path_join
 
@@ -62,7 +61,7 @@ class CreateHandler(BaseHandler):
     def post(self):
         value = self.get_argument('gistnorurl', '')
         redirect_url = transform_ipynb_uri(value, self.get_provider_rewrites())
-        app_log.info("create %s => %s", value, redirect_url)
+        self.log.info("create %s => %s", value, redirect_url)
         self.redirect(url_path_join(self.base_url, redirect_url))
 
     def get_provider_rewrites(self):

--- a/nbviewer/providers/gist/handlers.py
+++ b/nbviewer/providers/gist/handlers.py
@@ -5,8 +5,6 @@ import os
 import json
 
 from tornado import web
-from tornado.log import app_log
-
 
 from ..base import (
     BaseHandler,
@@ -213,12 +211,12 @@ class GistHandler(GistClientMixin, RenderingHandler):
         gist_id, filename, many_files_gist, file are all passed to file_get
         """
         if (file['type'] or '').startswith('image/'):
-            app_log.debug("Fetching raw image (%s) %s/%s: %s", file['type'], gist_id, filename, file['raw_url'])
+            self.log.debug("Fetching raw image (%s) %s/%s: %s", file['type'], gist_id, filename, file['raw_url'])
             response = await self.fetch(file['raw_url'])
             # use raw bytes for images:
             content = response.body
         elif file['truncated']:
-            app_log.debug("Gist %s/%s truncated, fetching %s", gist_id, filename, file['raw_url'])
+            self.log.debug("Gist %s/%s truncated, fetching %s", gist_id, filename, file['raw_url'])
             response = await self.fetch(file['raw_url'])
             content = response_text(response, encoding='utf-8')
         else:
@@ -265,7 +263,13 @@ class GistHandler(GistClientMixin, RenderingHandler):
         Encompasses both the case of a single file gist, handled by
         `file_get`, as well as a many-file gist, handled by `tree_get`.
         """
-        user, gist_id, gist, files, many_files_gist = await self.parse_gist(user, gist_id, filename)
+
+        parsed_gist = await self.parse_gist(user, gist_id, filename)
+
+        if parsed_gist is not None:
+            user, gist_id, gist, files, many_files_gist = parsed_gist
+        else:
+            return
 
         if many_files_gist and not filename:
             await self.tree_get(user, gist_id, gist, files)
@@ -289,7 +293,7 @@ class GistRedirectHandler(BaseHandler):
         if file:
             new_url = "%s/%s" % (new_url, file)
 
-        app_log.info("Redirecting %s to %s", self.request.uri, new_url)
+        self.log.info("Redirecting %s to %s", self.request.uri, new_url)
         self.redirect(self.from_base(new_url))
 
 

--- a/nbviewer/providers/github/tests/test_client.py
+++ b/nbviewer/providers/github/tests/test_client.py
@@ -3,6 +3,7 @@
 import unittest.mock as mock
 
 from tornado.httpclient import AsyncHTTPClient
+from tornado.log import app_log
 from tornado.testing import AsyncTestCase
 
 from ..client import AsyncGitHubClient
@@ -18,7 +19,7 @@ class GithubClientTest(AsyncTestCase):
         
         # patch the enviornment so that we get a known url prefix.
         with mock.patch('os.environ.get', return_value='https://api.github.com/'):
-            self.gh_client = AsyncGitHubClient(client=self.http_client)
+            self.gh_client = AsyncGitHubClient(log=app_log, client=self.http_client)
 
     def _get_url(self):
         """Get the last url requested from the mock http client."""

--- a/nbviewer/providers/url/handlers.py
+++ b/nbviewer/providers/url/handlers.py
@@ -12,7 +12,6 @@ from tornado import (
     httpclient,
     web,
 )
-from tornado.log import app_log
 from tornado.escape import url_unescape
 
 from ...utils import (
@@ -65,11 +64,11 @@ class URLHandler(RenderingHandler):
             rfp.parse(robotstxt.splitlines())
             public = rfp.can_fetch('*', remote_url)
         except httpclient.HTTPError as e:
-            app_log.debug("Robots.txt not available for {}".format(remote_url),
+            self.log.debug("Robots.txt not available for {}".format(remote_url),
                     exc_info=True)
             public = True
         except Exception as e:
-            app_log.error(e)
+            self.log.error(e)
 
         return remote_url, public
 
@@ -79,7 +78,7 @@ class URLHandler(RenderingHandler):
         try:
             nbjson = response_text(response, encoding='utf-8')
         except UnicodeDecodeError:
-            app_log.error("Notebook is not utf8: %s", remote_url, exc_info=True)
+            self.log.error("Notebook is not utf8: %s", remote_url, exc_info=True)
             raise web.HTTPError(400)
 
         await self.finish_notebook(nbjson, download_url=remote_url,

--- a/nbviewer/tests/base.py
+++ b/nbviewer/tests/base.py
@@ -18,6 +18,7 @@ from unittest import TestCase, skipIf
 
 from tornado.escape import to_unicode
 from tornado.ioloop import IOLoop
+from tornado.log import app_log
 import tornado.options
 
 from nbviewer.utils import url_path_join
@@ -146,6 +147,6 @@ def skip_unless_github_auth(f):
     callable
         unittest.skipIf decorated function
     """
-    cl = AsyncGitHubClient()
+    cl = AsyncGitHubClient(log=app_log)
     can_auth = 'access_token' in cl.auth or ('client_id' in cl.auth and 'client_secret' in cl.auth)
     return skipIf(not can_auth, 'github creds not available')(f)

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -24,9 +24,6 @@ from urllib.parse import (
     urlunparse,
 )
 
-from tornado.log import app_log
-
-
 STRIP_PARAMS = [
     'client_id',
     'client_secret',
@@ -235,7 +232,7 @@ def base64_encode(s):
 
 
 @contextmanager
-def time_block(message, debug_limit=1):
+def time_block(message, logger, debug_limit=1):
     """context manager for timing a block
 
     logs millisecond timings of the block
@@ -247,7 +244,7 @@ def time_block(message, debug_limit=1):
     tic = time.time()
     yield
     dt = time.time() - tic
-    log = app_log.info if dt > debug_limit else app_log.debug
+    log = logger.info if dt > debug_limit else logger.debug
     log("%s in %.2f ms", message, 1e3 * dt)
 
 def cached_property(method):


### PR DESCRIPTION
Unify all logging to a central log which is an attribute of the NBViewer class. Update format of logs to resemble that of other Jupyter applications, and to be more informative.

This involves a _temporary_ regression, since in order to use the `log_level` attribute of  `traitlets.config.Application`, and set it to `DEBUG` level via a command line flag, it is necessary to activate `traitlets` parsing of command line arguments, which can't be initiated until the migration of all `tornado.options` to `traitlets` is complete. I believe this is the reason why I previously had the changes to the logging and the entire migration to `traitlets` in one massive commit: I wanted to avoid any commits with even temporary feature regressions.

Again however this will involve zero loss of features, and the addition of several new features, after all `tornado.options` are replaced with `traitlets` and command line parsing is handed over to `traitlets` from `tornado.options`.
