### PR TITLE
Step7_12

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
@@ -36,7 +36,7 @@ from .formats import default_formats
 from nbconvert.exporters.export import exporter_map
 
 from .providers import default_providers, default_rewrites
-from .providers.url.client import NBViewerAsyncHTTPClient as HTTPClientClass
+from .client import NBViewerAsyncHTTPClient as HTTPClientClass
 from .ratelimit import RateLimiter
 
 from .log import log_request
@@ -248,7 +248,7 @@ class NBViewer(Application):
     # Ditto the above: https://github.com/ipython/traitlets/blob/master/traitlets/config/application.py#L197
     @default('log_format')
     def _log_format_default(self):
-        """override default log format to include time and color, plus always display the log level, not just when it's high"""
+        """override default log format to include time and color, plus to always display the log level, not just when it's high"""
         return "%(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s %(module)s:%(lineno)d]%(end_color)s %(message)s"
 
     # For consistency with JupyterHub logs

--- a/nbviewer/cache.py
+++ b/nbviewer/cache.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/client.py
+++ b/nbviewer/client.py
@@ -13,7 +13,7 @@ import time
 
 import asyncio
 
-from tornado.httpclient import HTTPRequest, HTTPError
+from tornado.httpclient import HTTPRequest
 from tornado.curl_httpclient import CurlAsyncHTTPClient
 
 from nbviewer.utils import time_block

--- a/nbviewer/formats.py
+++ b/nbviewer/formats.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2015 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/index.py
+++ b/nbviewer/index.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2014 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/log.py
+++ b/nbviewer/log.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/providers/__init__.py
+++ b/nbviewer/providers/__init__.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/providers/dropbox/handlers.py
+++ b/nbviewer/providers/dropbox/handlers.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/providers/gist/tests/test_gist.py
+++ b/nbviewer/providers/gist/tests/test_gist.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/providers/github/client.py
+++ b/nbviewer/providers/github/client.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
@@ -9,7 +9,6 @@ import os
 import json
 import mimetypes
 import re
-import asyncio
 
 from tornado import (
     web,

--- a/nbviewer/providers/github/tests/test_github.py
+++ b/nbviewer/providers/github/tests/test_github.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/providers/local/tests/test_localfile.py
+++ b/nbviewer/providers/local/tests/test_localfile.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/providers/url/handlers.py
+++ b/nbviewer/providers/url/handlers.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/providers/url/tests/test_url.py
+++ b/nbviewer/providers/url/tests/test_url.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/render.py
+++ b/nbviewer/render.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/tests/base.py
+++ b/nbviewer/tests/base.py
@@ -4,7 +4,7 @@ Derived from IPython.html notebook test case in 2.0
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/tests/test_format_slides.py
+++ b/nbviewer/tests/test_format_slides.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/tests/test_security.py
+++ b/nbviewer/tests/test_security.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2015 The Jupyter Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/tests/test_utils.py
+++ b/nbviewer/tests/test_utils.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/nbviewer/utils.py
+++ b/nbviewer/utils.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2013 The IPython Development Team
+#  Copyright (C) Jupyter Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.


### PR DESCRIPTION
Moved client file to base since it's used by the NBViewer application, not specifically the URL provider. Removed some unused imports, updated copyright statements, and general tidying before tornado.options -> traitlets migration