### PR TITLE
BaseHandler.prepare is async now

### DIFF
--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -24,8 +24,8 @@ from .providers.base import (
 
 class Custom404(BaseHandler):
     """Render our 404 template"""
-    async def prepare(self):
-        await super().prepare()
+    def prepare(self):
+        # skip parent prepare() step, just render the 404
         raise web.HTTPError(404)
 
 

--- a/nbviewer/handlers.py
+++ b/nbviewer/handlers.py
@@ -24,8 +24,8 @@ from .providers.base import (
 
 class Custom404(BaseHandler):
     """Render our 404 template"""
-    def prepare(self):
-        super().prepare()
+    async def prepare(self):
+        await super().prepare()
         raise web.HTTPError(404)
 
 


### PR DESCRIPTION
<del>needs to be awaited</del>

turns out the async prepare didn't work in the 404 handler! We only got past this because we weren't waiting for the result. Better to skip altogether than start and never await it.