### PR TITLE
nbviewer.jupyter.org is now* hosted on OVH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Jupyter Notebook Viewer
 
-Jupyter nbviewer is the web application behind [The Jupyter Notebook Viewer](http://nbviewer.ipython.org), which is graciously hosted by [Rackspace](https://developer.rackspace.com/?nbviewer=awesome).
+Jupyter nbviewer is the web application behind
+[The Jupyter Notebook Viewer](http://nbviewer.jupyter.org),
+which is graciously hosted by [OVH](https://www.ovh.com).
 
 Run this locally to get most of the features of nbviewer on your own network.
 

--- a/nbviewer/templates/faq.md
+++ b/nbviewer/templates/faq.md
@@ -159,9 +159,10 @@ the [nbconvert documentation](https://nbconvert.readthedocs.io/) for details.
 
 ## Where is nbviewer.jupyter.org hosted?
 
-[Rackspace](https://developer.rackspace.com/?nbviewer=awesome) graciously hosts
-nbviewer.jupyter.org. Thanks to Rackspace, we are able to provider a public
-nbviewer instance as a free service.
+[OVH](https://www.ovh.com) graciously hosts nbviewer.jupyter.org.
+Thanks to OVH, we are able to provider a public nbviewer instance as a free service.
+
+nbviewer was generously hosted by Rackspace until March, 2020.
 
 ## Can I access nbviewer.jupyter.org over https?
 

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -131,7 +131,7 @@
         <div class="col-md-4">
           <p>
             Delivered by <a href="http://www.fastly.com/">Fastly</a>,
-            Rendered by <a href="https://developer.rackspace.com/?nbviewer=awesome">Rackspace</a>
+            Rendered by <a href="https://www.ovh.com">OVH</a>
           </p>
           <p>
             nbviewer GitHub <a href="https://github.com/jupyter/nbviewer">repository</a>.


### PR DESCRIPTION
\* partially for now, soon to be fully moved over