### PR TITLE
Update code for nbconvert >= 6.0 (#958, #953) 

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 import markdown
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
-from nbconvert.exporters.export import exporter_map
+from nbconvert import get_exporter
 from tornado import httpserver
 from tornado import ioloop
 from tornado import web
@@ -594,15 +594,15 @@ class NBViewer(Application):
             formats = default_formats()
 
         # This would be better defined in a class
-        self.config.HTMLExporter.template_file = "basic"
+        self.config.HTMLExporter.template_name = "basic"
         self.config.SlidesExporter.template_file = "slides_reveal"
 
-        self.config.TemplateExporter.template_path = [
+        self.config.TemplateExporter.extra_template_basedirs = [
             os.path.join(os.path.dirname(__file__), "templates", "nbconvert")
         ]
 
         for key, format in formats.items():
-            exporter_cls = format.get("exporter", exporter_map[key])
+            exporter_cls = format.get("exporter", get_exporter(key))
             if self.processes:
                 # can't pickle exporter instances,
                 formats[key]["exporter"] = exporter_cls

--- a/nbviewer/index.py
+++ b/nbviewer/index.py
@@ -50,5 +50,5 @@ class ElasticSearch(Indexer):
             )
         else:
             app_log.info(
-                "Indexing old notebook={}, public={}".format(notebook_url, public, resp)
+                "Indexing old notebook={}, public={}".format(notebook_url, public)
             )

--- a/nbviewer/templates/faq.md
+++ b/nbviewer/templates/faq.md
@@ -51,7 +51,7 @@ nbviewer does not execute notebooks. It only renders the inputs and outputs
 saved in a notebook document as a web page.
 
 [mybinder.org](https://mybinder.org/) is a separate web service that lets you
-open notebooks notebooks in an executable environment, making your code
+open notebooks in an executable environment, making your code
 immediately reproducible by anyone, anywhere. nbviewer shows an *Execute on
 Binder* icon in its navbar which
 
@@ -103,7 +103,7 @@ instructions and options.
 
 The URL you are visiting most likely points to a notebook that was moved or
 deleted. If you clicked a link on a site that lead to the 404 error page, we
-suggest you contact the site auownerthor to report the broken link. If a
+suggest you contact the site owner to report the broken link. If a
 notebook author gave you the URL, we recommend asking them for an updated link.
 
 If you notice one of the links on the nbviewer.jupyter.org, please report it as


### PR DESCRIPTION
Hi,

Ran into the same problem as issue #958. I had to make several changes to get it to work; not all of them I'm fully confident with.

- had to replace `exporter_map` from nbconvert with `get_exporter` function..
- the `template_file` in HTMLExporter didn't roll...  so I updated it to `template_name`... 🤨.

Leaving out the second fix will result in the following error:

```
    Traceback (most recent call last):
      File "/usr/local/lib/python3.7/site-packages/nbviewer/providers/base.py", line 727, in finish_notebook
        self.config,
      File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
        result = self.fn(*self.args, **self.kwargs)
      File "/usr/local/lib/python3.7/site-packages/nbviewer/render.py", line 56, in render_notebook
        html, resources = exporter.from_notebook_node(nb)
      File "/usr/local/lib/python3.7/site-packages/nbconvert/exporters/html.py", line 119, in from_notebook_node
        return super().from_notebook_node(nb, resources, **kw)
      File "/usr/local/lib/python3.7/site-packages/nbconvert/exporters/templateexporter.py", line 384, in from_notebook_node
        output = self.template.render(nb=nb_copy, resources=resources)
      File "/usr/local/lib/python3.7/site-packages/nbconvert/exporters/templateexporter.py", line 148, in template
        self._template_cached = self._load_template()
      File "/usr/local/lib/python3.7/site-packages/nbconvert/exporters/templateexporter.py", line 355, in _load_template
        return self.environment.get_template(template_file)
      File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 883, in get_template
        return self._load_template(name, self.make_globals(globals))
      File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 857, in _load_template
        template = self.loader.load(self, name, globals)
      File "/usr/local/lib/python3.7/site-packages/jinja2/loaders.py", line 429, in load
        raise TemplateNotFound(name)
    jinja2.exceptions.TemplateNotFound: basic
```

While I was waiting for the docker build I fixed 2 typos from #947 . 

I'm not sure if this is merge-worthy... feedback or a better solution would be appreciated.

[Edit]: also some help with solving all the weird 503 errors in the automated test is welcome. Not sure what I broke here..
