### PR TITLE
switch master to default branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v1.3.5
   hooks:
   - id: reorder-python-imports
-    language_version: python3.6
+    language_version: python3
 - repo: https://github.com/ambv/black
   rev: 18.9b0
   hooks:

--- a/nbviewer/providers/github/client.py
+++ b/nbviewer/providers/github/client.py
@@ -135,6 +135,11 @@ class AsyncGitHubClient(object):
         path = u"users/{user}/gists".format(user=user)
         return self.github_api_request(path, **kwargs)
 
+    def get_repo(self, user, repo, **kwargs):
+        """List a repo's branches"""
+        path = u"repos/{user}/{repo}".format(user=user, repo=repo)
+        return self.github_api_request(path, **kwargs)
+
     def get_tree(self, user, repo, path, ref="master", recursive=False, **kwargs):
         """Get a git tree"""
         # only need a recursive fetch if it's not in the top-level dir

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -141,12 +141,15 @@ class GitHubUserHandler(GithubClientMixin, BaseHandler):
         await self.cache_and_finish(html)
 
 
-class GitHubRepoHandler(BaseHandler):
+class GitHubRepoHandler(GithubClientMixin, BaseHandler):
     """redirect /github/user/repo to .../tree/master"""
 
-    def get(self, user, repo):
+    async def get(self, user, repo):
+        response = await self.github_client.get_repo(user, repo)
+        default_branch = json.loads(response_text(response))['default_branch']
+
         new_url = self.from_base(
-            "/", self.format_prefix, "github", user, repo, "tree", "master"
+            "/", self.format_prefix, "github", user, repo, "tree", default_branch
         )
         self.log.info("Redirecting %s to %s", self.request.uri, new_url)
         self.redirect(new_url)

--- a/nbviewer/providers/github/handlers.py
+++ b/nbviewer/providers/github/handlers.py
@@ -146,7 +146,7 @@ class GitHubRepoHandler(GithubClientMixin, BaseHandler):
 
     async def get(self, user, repo):
         response = await self.github_client.get_repo(user, repo)
-        default_branch = json.loads(response_text(response))['default_branch']
+        default_branch = json.loads(response_text(response))["default_branch"]
 
         new_url = self.from_base(
             "/", self.format_prefix, "github", user, repo, "tree", default_branch


### PR DESCRIPTION
This addresses the issue where the github repo/user URL in  nbviewer defaults to master. Instead we pull the value of default_branch from the GH API and and use that. 

Note that I didn't change the uri_rewrites because I don't think these are being used - but let me know if I missed something. 