### PR TITLE
Removes broken links (404s and pages with missing visualizations)

### DIFF
--- a/nbviewer/frontpage.json
+++ b/nbviewer/frontpage.json
@@ -47,16 +47,6 @@
      "header":"Misc",
      "links":[
        {
-         "text": "Data Visualization with Lightning",
-         "target": "/github/lightning-viz/lightning-example-notebooks/blob/master/index.ipynb",
-         "img": "/img/example-nb/lightning.png"
-       },
-       {
-         "text": "Interactive plots with Plotly",
-         "target": "/github/plotly/python-user-guide/blob/master/Index.ipynb",
-         "img": "/img/example-nb/plotly.png"
-       },
-       {
          "text": "XKCD Plot With Matplotlib",
          "target": "/url/jakevdp.github.io/downloads/notebooks/XKCD_plots.ipynb",
          "img": "/img/example-nb/XKCD-Matplotlib.png"


### PR DESCRIPTION
Addressing #826, this change removes links that either go to 404 pages or to pages with broken embeds of images. I based these changes on a quick browse through nbviewer.org earlier today, viewing each link to see whether it refers to an existing file with all embeds intact.