### PR TITLE
Add project URLs to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,11 @@ setup_args = dict(
     author="The Jupyter Development Team",
     author_email="jupyter@googlegroups.com",
     url="https://nbviewer.jupyter.org",
+    project_urls={
+        "Documentation": "https://nbviewer.jupyter.org/",
+        "Source": "https://github.com/jupyter/nbviewer",
+        "Tracker": "https://github.com/jupyter/nbviewer/issues",
+    },
     description="Jupyter Notebook Viewer",
     long_description="Jupyter nbconvert as a web service",
     license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup_args = dict(
     author_email="jupyter@googlegroups.com",
     url="https://nbviewer.jupyter.org",
     project_urls={
-        "Documentation": "https://nbviewer.jupyter.org/",
+        "Documentation": "https://nbviewer.org/",
         "Source": "https://github.com/jupyter/nbviewer",
         "Tracker": "https://github.com/jupyter/nbviewer/issues",
     },


### PR DESCRIPTION
Adding project URLs (especially source code URL) makes it easier for dependency management tools (like Renovate).