### PR TITLE
Add provider for huggingface.co: Very basic `uri_rewrites`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Providers are sources of notebooks and directories of notebooks and directories.
 - `url`
 - `gist`
 - `github`
+- `huggingface`
 - `local`
 
 #### Writing a new Provider

--- a/nbviewer/providers/__init__.py
+++ b/nbviewer/providers/__init__.py
@@ -11,7 +11,7 @@ default_providers = [
 
 default_rewrites = [
     "nbviewer.providers.{}".format(prov)
-    for prov in ["gist", "github", "dropbox", "url"]
+    for prov in ["gist", "github", "dropbox", "huggingface", "url"]
 ]
 
 

--- a/nbviewer/providers/huggingface/__init__.py
+++ b/nbviewer/providers/huggingface/__init__.py
@@ -1,0 +1,3 @@
+from .handlers import uri_rewrites
+
+__all__ = ["uri_rewrites"]

--- a/nbviewer/providers/huggingface/handlers.py
+++ b/nbviewer/providers/huggingface/handlers.py
@@ -1,0 +1,15 @@
+# -----------------------------------------------------------------------------
+#  Copyright (C) Jupyter Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+# -----------------------------------------------------------------------------
+
+
+def uri_rewrites(rewrites=[]):
+    return rewrites + [
+        (
+            r"^https://huggingface.co/(.+?)/blob/(.+?)$",
+            "/urls/huggingface.co/{0}/resolve/{1}",
+        )
+    ]

--- a/nbviewer/templates/index.html
+++ b/nbviewer/templates/index.html
@@ -18,7 +18,7 @@
              type="text"
              name="gistnorurl"
              autofocus="autofocus"
-             placeholder="URL | GitHub username | GitHub username/repo | Gist ID"/>
+             placeholder="URL | GitHub username | GitHub username/repo | Gist ID | HuggingFace URL"/>
             <span class="input-group-btn">
               <button class="btn btn-default" type="submit" type="button">
                 Go!

--- a/nbviewer/tests/test_utils.py
+++ b/nbviewer/tests/test_utils.py
@@ -45,6 +45,21 @@ def test_transform_ipynb_uri():
             "https://www.dropbox.com/sh/mhviow274da2wly/CZKwRRcA0k/nested/furthernested/User%2520Interface.ipynb?dl=1",
             "/urls/dl.dropbox.com/sh/mhviow274da2wly/CZKwRRcA0k/nested/furthernested/User%2520Interface.ipynb",
         ),
+        # HuggingFace urls
+        (
+            "https://huggingface.co/pceiyos/fake_news_detection_nlp/blob/main/Fake_News_Classificaton.ipynb",
+            "/urls/huggingface.co/pceiyos/fake_news_detection_nlp/resolve/main/Fake_News_Classificaton.ipynb",
+        ),
+        (
+            "https://huggingface.co/spaces/NimaBoscarino/climategan/blob/main/notebooks/plot_metrics.ipynb",
+            "/urls/huggingface.co/spaces/NimaBoscarino/climategan/resolve/main/notebooks/plot_metrics.ipynb",
+            # This ClimateGAN notebook is served over LFS (as the file is 17.1 MB)
+        ),
+        (
+            "https://huggingface.co/spaces/dalle-mini/dalle-mini/blob/63679e968109278c5f0169100b1755bbda9f4bc6/tools/inference/inference_pipeline.ipynb",
+            "/urls/huggingface.co/spaces/dalle-mini/dalle-mini/resolve/63679e968109278c5f0169100b1755bbda9f4bc6/tools/inference/inference_pipeline.ipynb",
+            # This Dall-e mini notebook is hosted from a specific revision (= git commit)
+        ),
         # URL
         ("https://example.org/ipynb", "/urls/example.org/ipynb"),
         ("http://example.org/ipynb", "/url/example.org/ipynb"),


### PR DESCRIPTION
Hi!

I use https://nbviewer.org/ quite a bit and we are also considering implementing a notebook-rendering service on [huggingface.co](https://huggingface.co) that could potentially be built on top of nbconvert and/or nbviewer.

As a quick useful feature, I added URL rewrite from huggingface "blob" URLs, i.e. those you get when navigating to a ipynb file inside a repository, to the "resolve" URLs which we use to serve actual content.

This works for both:
- files stored in raw git: e.g. https://huggingface.co/pceiyos/fake_news_detection_nlp/blob/main/Fake_News_Classificaton.ipynb
- files stored in LFS, i.e. large notebooks over 10MB (also related to #664): https://huggingface.co/spaces/NimaBoscarino/climategan/blob/main/notebooks/plot_metrics.ipynb

Let me know if this looks ok!