### PR TITLE
Validate JUPYTERHUB_SERVICE_URL port number

### DIFF
--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -458,6 +458,11 @@ class NBViewer(Application):
         if "JUPYTERHUB_SERVICE_URL" in os.environ:
             url = urlparse(os.environ["JUPYTERHUB_SERVICE_URL"])
             default_host, default_port = url.hostname, url.port
+
+            if default_port < 1 or default_port > 65535:
+                self.log.error("Received invalid port number %d through JUPYTERHUB_SERVICE_URL. "
+                               "Defaulting to 5000 instead.")
+                default_port = 5000
         else:
             default_host, default_port = "0.0.0.0", 5000
         return {"host": default_host, "port": default_port}

--- a/nbviewer/app.py
+++ b/nbviewer/app.py
@@ -460,8 +460,10 @@ class NBViewer(Application):
             default_host, default_port = url.hostname, url.port
 
             if default_port < 1 or default_port > 65535:
-                self.log.error("Received invalid port number %d through JUPYTERHUB_SERVICE_URL. "
-                               "Defaulting to 5000 instead.")
+                self.log.error(
+                    "Received invalid port number %d through JUPYTERHUB_SERVICE_URL. "
+                    "Defaulting to 5000 instead."
+                )
                 default_port = 5000
         else:
             default_host, default_port = "0.0.0.0", 5000


### PR DESCRIPTION
This PR is related to the problem identified in https://github.com/jupyter/docker-stacks/issues/1862 .

When a `JUPYTERHUB_SERVICE_URL` is received with port number 0 (which is a [valid usecase according to @minrk](https://github.com/jupyterhub/jupyterhub/pull/4310#discussion_r1087651448), some mechanism triggers which causes the Jupyter server to start running on port 80 instead of the default port 8888. Even when a `JUPYTER_PORT` environment variable is set, this value is ignored. I'm not sure where/why this exactly happens. 

This seems to be the only place where `JUPYTERHUB_SERVICE_URL` is parsed. When an invalid port number `0` is received, I think it is best to log a warning and revert to the default port `5000` instead.