### PR TITLE
feat(nbviwer): add OAuth2 support for jupyterhub > 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ MANIFEST
 package-lock.json
 .vscode/
 *.tgz
+.idea

--- a/README.md
+++ b/README.md
@@ -237,3 +237,84 @@ c.JupyterHub.services = [
 ```
 
 The nbviewer instance will automatically read the [various `JUPYTERHUB_*` environment variables](http://jupyterhub.readthedocs.io/en/latest/reference/services.html#launching-a-hub-managed-service) and configure itself accordingly. You can also run the nbviewer instance as an [externally managed JupyterHub service](http://jupyterhub.readthedocs.io/en/latest/reference/services.html#externally-managed-services), but must set the requisite environment variables yourself.
+
+---
+
+# nbviewer Integration with JupyterHub via OAuth2
+
+This guide explains how to configure **nbviewer** as a JupyterHub service using OAuth2 token-based authentication.
+
+## Requirements
+- **JupyterHub** (version 2.x or higher)
+- **nbviewer** service
+- Access to the environment variables for both **JupyterHub** and **nbviewer**.
+
+
+## JupyterHub Configuration
+
+In JupyterHub’s `jupyterhub_config.py`, add the following configuration to integrate nbviewer as a service:
+
+```python
+c.JupyterHub.services.append(
+    {
+        'name': 'nbviewer',
+        'url': 'http://nbviewer:8080',
+        'api_token': os.environ['JUPYTERHUB_API_TOKEN'],
+        'oauth_no_confirm': True,
+        'oauth_client_id': 'service-nbviewer',
+        'oauth_redirect_uri': 'https://jupyterhub.yourcompany.com/services/nbviewer/oauth_callback',
+    }
+)
+
+c.JupyterHub.load_roles = [
+    {
+        'name': 'nbviewer',
+        'services': ['nbviewer', 'jupyterhub-idle-culler'],
+        'scopes': [
+            "read:users:activity",
+            "list:users",
+            "users:activity",
+            "servers", # For starting and stopping servers
+            'admin:users' # Needed if idle users are culled
+        ]
+    }
+]
+
+c.JupyterHub.service_tokens = {
+    os.environ['JUPYTERHUB_API_TOKEN'] : 'nbviewer' 
+}
+```
+
+### Explanation of Key Settings:
+- oauth_client_id: The unique ID for the nbviewer service.
+- oauth_redirect_uri: The URL that nbviewer uses to handle OAuth2 callbacks from JupyterHub.
+- service_tokens: Set the service token used by nbviewer to authenticate with JupyterHub.
+
+## nbviewer Configuration
+In the deployment of nbviewer, configure the following environment variables:
+```yaml
+extraEnv:
+  JUPYTERHUB_SERVICE_NAME: 'nbviewer'
+  JUPYTERHUB_API_URL: 'http://hub:8081/hub/api'
+  JUPYTERHUB_BASE_URL: '/'
+  JUPYTERHUB_SERVICE_PREFIX: '/services/nbviewer/'
+  JUPYTERHUB_URL: 'https://jupyterhub.yourcompany.com'
+  JUPYTERHUB_CLIENT_ID: 'service-nbviewer'
+```
+### Explanation of Environment Variables:
+- JUPYTERHUB_API_URL: The internal URL where nbviewer can access JupyterHub’s API.
+- JUPYTERHUB_URL: The base URL of your JupyterHub installation (public-facing).
+- JUPYTERHUB_CLIENT_ID: Should match the oauth_client_id in the JupyterHub configuration.
+- JUPYTERHUB_SERVICE_PREFIX: Specifies the service's routing prefix.
+
+### OAuth2 Flow
+When a user accesses nbviewer, they will be authenticated via the OAuth2 token from JupyterHub. The oauth_callback URL specified in the configuration will be used to handle the token exchange.
+
+Ensure nbviewer correctly handles OAuth2 requests by ensuring the callback URL is properly set and that nbviewer is able to request the necessary scopes from JupyterHub.
+
+### Troubleshooting
+If you encounter issues with token authentication or authorization, ensure that:
+The correct API token is set both in JupyterHub and nbviewer.
+The service roles and scopes are correctly configured to allow nbviewer access to JupyterHub's user data.
+
+---

--- a/nbviewer/providers/base.py
+++ b/nbviewer/providers/base.py
@@ -97,6 +97,7 @@ class BaseHandler(web.RequestHandler):
         """
         # if any of these are set, assume we want to do auth, even if
         # we're misconfigured (better safe than sorry!)
+
         if self.hub_api_url or self.hub_api_token or self.hub_base_url:
 
             def redirect_to_login():
@@ -106,28 +107,44 @@ class BaseHandler(web.RequestHandler):
                     + urlencode({"next": self.request.path})
                 )
 
-            encrypted_cookie = self.get_cookie(self.hub_cookie_name)
-            if not encrypted_cookie:
-                # no cookie == not authenticated
-                return redirect_to_login()
+            def redirect_to_authorize():
 
-            try:
-                # if the hub returns a success code, the user is known
-                await self.http_client.fetch(
-                    url_path_join(
-                        self.hub_api_url,
-                        "authorizations/cookie",
-                        self.hub_cookie_name,
-                        quote(encrypted_cookie, safe=""),
-                    ),
-                    headers={"Authorization": "token " + self.hub_api_token},
+                self.redirect(
+                    url_path_join(self.hub_base_url, "/hub/api/oauth2/authorize")
+                    + "?"
+                    + urlencode({"client_id": self.client_id, "response_type": "code"})
                 )
-            except httpclient.HTTPError as ex:
-                if ex.response.code == 404:
-                    # hub does not recognize the cookie == not authenticated
+
+            # if we have a redirect URL, we're running OAuth2 authentication
+            if self.redirect_url:
+                # token = self.get_current_user()
+                token = self.get_secure_cookie(self.hub_cookie_name)
+                if not token:
+                    redirect_to_authorize()
+            else:
+                # support old authentication method via authorizations/cookie
+                encrypted_cookie = self.get_cookie(self.hub_cookie_name)
+                if not encrypted_cookie:
+                    # no cookie == not authenticated
                     return redirect_to_login()
-                # let all other errors surface: they're unexpected
-                raise ex
+
+                try:
+                    # if the hub returns a success code, the user is known
+                    await self.http_client.fetch(
+                        url_path_join(
+                            self.hub_api_url,
+                            "authorizations/cookie",
+                            self.hub_cookie_name,
+                            quote(encrypted_cookie, safe=""),
+                        ),
+                        headers={"Authorization": "token " + self.hub_api_token},
+                    )
+                except httpclient.HTTPError as ex:
+                    if ex.response.code == 404:
+                        # hub does not recognize the cookie == not authenticated
+                        return redirect_to_login()
+                    # let all other errors surface: they're unexpected
+                    raise ex
 
     # Properties
 
@@ -138,6 +155,10 @@ class BaseHandler(web.RequestHandler):
     @property
     def binder_base_url(self):
         return self.settings["binder_base_url"]
+
+    @property
+    def redirect_url(self):
+        return self.settings["redirect_uri"]
 
     @property
     def cache(self):
@@ -189,7 +210,7 @@ class BaseHandler(web.RequestHandler):
 
     @property
     def hub_cookie_name(self):
-        return "jupyterhub-services"
+        return self.settings["hub_cookie_name"]
 
     @property
     def index(self):
@@ -254,6 +275,14 @@ class BaseHandler(web.RequestHandler):
             # return an empty mock object!
             self._statsd = EmptyClass()
             return self._statsd
+
+    @property
+    def authorize_url(self):
+        return self.settings["authorize_url"]
+
+    @property
+    def client_id(self):
+        return self.settings["client_id"]
 
     # ---------------------------------------------------------------
     # template rendering
@@ -677,7 +706,7 @@ class RenderingHandler(BaseHandler):
                 self.base_url, "/"
             ),
             date=datetime.utcnow().strftime(self.date_fmt),
-            **namespace
+            **namespace,
         )
 
     async def finish_notebook(
@@ -746,7 +775,7 @@ class RenderingHandler(BaseHandler):
             nb=nb,
             download_url=download_url,
             json_notebook=json_notebook,
-            **namespace
+            **namespace,
         )
         html_time.stop()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ mock>=1.3.0  # python34 and older versions of mock do not play well together.
 pre-commit
 pytest
 requests
+jupyterhub


### PR DESCRIPTION
# nbviewer Integration with JupyterHub via OAuth2

This guide explains how to configure **nbviewer** as a JupyterHub service using OAuth2 token-based authentication.

## Requirements
- **JupyterHub** (version 2.x or higher)
- **nbviewer** service
- Access to the environment variables for both **JupyterHub** and **nbviewer**.


## JupyterHub Configuration

In JupyterHub’s `jupyterhub_config.py`, add the following configuration to integrate nbviewer as a service:

```python
c.JupyterHub.services.append(
    {
        'name': 'nbviewer',
        'url': 'http://nbviewer:8080',
        'api_token': os.environ['JUPYTERHUB_API_TOKEN'],
        'oauth_no_confirm': True,
        'oauth_client_id': 'service-nbviewer',
        'oauth_redirect_uri': 'https://jupyterhub.yourcompany.com/services/nbviewer/oauth_callback',
    }
)

c.JupyterHub.load_roles = [
    {
        'name': 'nbviewer',
        'services': ['nbviewer', 'jupyterhub-idle-culler'],
        'scopes': [
            "read:users:activity",
            "list:users",
            "users:activity",
            "servers", # For starting and stopping servers
            'admin:users' # Needed if idle users are culled
        ]
    }
]

c.JupyterHub.service_tokens = {
    os.environ['JUPYTERHUB_API_TOKEN'] : 'nbviewer' 
}
```

### Explanation of Key Settings:
- oauth_client_id: The unique ID for the nbviewer service.
- oauth_redirect_uri: The URL that nbviewer uses to handle OAuth2 callbacks from JupyterHub.
- service_tokens: Set the service token used by nbviewer to authenticate with JupyterHub.

## nbviewer Configuration
In the deployment of nbviewer, configure the following environment variables:
```yaml
extraEnv:
  JUPYTERHUB_SERVICE_NAME: 'nbviewer'
  JUPYTERHUB_API_URL: 'http://hub:8081/hub/api'
  JUPYTERHUB_BASE_URL: '/'
  JUPYTERHUB_SERVICE_PREFIX: '/services/nbviewer/'
  JUPYTERHUB_URL: 'https://jupyterhub.yourcompany.com'
  JUPYTERHUB_CLIENT_ID: 'service-nbviewer'
```
### Explanation of Environment Variables:
- JUPYTERHUB_API_URL: The internal URL where nbviewer can access JupyterHub’s API.
- JUPYTERHUB_URL: The base URL of your JupyterHub installation (public-facing).
- JUPYTERHUB_CLIENT_ID: Should match the oauth_client_id in the JupyterHub configuration.
- JUPYTERHUB_SERVICE_PREFIX: Specifies the service's routing prefix.

### OAuth2 Flow
When a user accesses nbviewer, they will be authenticated via the OAuth2 token from JupyterHub. The oauth_callback URL specified in the configuration will be used to handle the token exchange.

Ensure nbviewer correctly handles OAuth2 requests by ensuring the callback URL is properly set and that nbviewer is able to request the necessary scopes from JupyterHub.

### Troubleshooting
If you encounter issues with token authentication or authorization, ensure that:
The correct API token is set both in JupyterHub and nbviewer.
The service roles and scopes are correctly configured to allow nbviewer access to JupyterHub's user data.

---
