### PR TITLE
Replace `set-output` with `$GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -17,12 +17,12 @@ jobs:
         run: |
           short_sha=$(git rev-parse --short HEAD)
           image="jupyter/nbviewer:$short_sha"
-          echo "::set-output name=image::$image"
+          echo "image=$image" >> $GITHUB_OUTPUT
           tags="$image"
           if "${{ github.ref_name }}" == "main" ]]; then
             tags="jupyter/nbviewer:latest $tags"
           fi
-          echo "::set-output name=tags::$tags"
+          echo "tags=$tags" >> $GITHUB_OUTPUT
 
       - name: Check outputs
         run: echo ${{ steps.vars.outputs.sha_short }}


### PR DESCRIPTION
Hi all, a colleague highlighted to me that this repo is using `set-output` within GitHub Actions, and that this has now been deprecated, with guidance provided for replacing:

[GitHub Actions: Deprecating save-state and set-output commands - GitHub Changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

Thanks!

