### PR TITLE
Drop Python 3.8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
     steps:

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup_args = dict(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     cmdclass=cmdclass,
 )
 


### PR DESCRIPTION
Hi all, since [Python 3.8 is now end-of-life](https://devguide.python.org/versions/), I thought I would put up a PR that removes it from this repo. Thanks