### PR TITLE
Add jupytercon link to navbar

### DIFF
--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -102,7 +102,7 @@
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-right">
           <li>
-            <a class="active" href="http://jupytercon.org">🚀 JUPYTERCON 2025 · NOV 4-5</a>
+            <a class="active" href="http://jupytercon.com">🚀 JUPYTERCON 2025 · NOV 4-5</a>
           </li>
           <li>
             <a class="active" href="http://jupyter.org">JUPYTER</a>

--- a/nbviewer/templates/layout.html
+++ b/nbviewer/templates/layout.html
@@ -102,6 +102,9 @@
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-right">
           <li>
+            <a class="active" href="http://jupytercon.org">🚀 JUPYTERCON 2025 · NOV 4-5</a>
+          </li>
+          <li>
             <a class="active" href="http://jupyter.org">JUPYTER</a>
           </li>
           {{ head_text(from_base('/faq'), "FAQ") }}


### PR DESCRIPTION
This adds a link to jupytercon 2025 in the navbar. I couldn't figure out how to make a banner header, so I added it as an additional link. Hopefully it is minimal enough that it wouldn't be disruptive. Here's a screenshot of what it looks like:

<img width="2962" height="1422" alt="CleanShot 2025-09-19 at 19 20 37@2x" src="https://github.com/user-attachments/assets/6f3f77c0-c4f5-4786-a336-85742843f13f" />
