### PR TITLE
Fix path-containment bypass in LocalFileHandler.can_show

### DIFF
--- a/nbviewer/providers/local/handlers.py
+++ b/nbviewer/providers/local/handlers.py
@@ -99,7 +99,16 @@ class LocalFileHandler(RenderingHandler):
                 os.path.normpath(os.path.join(self.localfile_path, path))
             )
 
-        if not fullpath.startswith(self.localfile_path):
+        # Enforce directory containment, not mere string-prefix containment.
+        # A bare startswith() check lets a sibling directory whose absolute
+        # path shares the configured root as a string prefix slip through,
+        # e.g. localfile_path "/data/notebooks" would wrongly accept
+        # "/data/notebooks_backup/secret.ipynb". Comparing against the root
+        # with a trailing separator (plus the root itself) closes that gap.
+        base = self.localfile_path
+        if not base.endswith(os.sep):
+            base += os.sep
+        if not (fullpath == self.localfile_path or fullpath.startswith(base)):
             self.log.warn("Directory traversal attempt: '%s'" % fullpath)
             return False
 


### PR DESCRIPTION
can_show() guarded the localfiles root with a bare `fullpath.startswith(self.localfile_path)` check. Because that is a string comparison rather than a path comparison, a sibling directory whose absolute path shares the configured root as a string prefix passes the guard. For example, with `--localfiles /data/notebooks`, a request resolving to `/data/notebooks_backup/credentials.ipynb` satisfies `startswith("/data/notebooks")` and is served, leaking files outside the intended root (CWE-22).

Compare against the root joined with a trailing separator (and accept the root itself) so only genuine descendants of the root are allowed. Classical `../../../etc` traversal remains blocked as before.

Fixes #1115